### PR TITLE
Change Reference from AutoClosable to use finaliza for GC

### DIFF
--- a/src/main/java/com/github/git24j/core/AnnotatedCommit.java
+++ b/src/main/java/com/github/git24j/core/AnnotatedCommit.java
@@ -35,6 +35,7 @@ public class AnnotatedCommit extends CAutoCloseable {
 
     /**
      * Initialize {@link AnnotatedCommit} from FETCH_HEAD data
+     *
      * @param repo git repository
      * @param branchName branch name, nonnull
      * @param remoteUrl remote url, nonnull

--- a/src/main/java/com/github/git24j/core/Branch.java
+++ b/src/main/java/com/github/git24j/core/Branch.java
@@ -26,17 +26,20 @@ public class Branch {
         return new Reference(outRef.get());
     }
 
-//    /**int git_branch_create_from_annotated(git_reference **ref_out, git_repository *repository, const char *branch_name, const git_annotated_commit *commit, int force); */
-//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniCreateFromAnnotated)(JNIEnv *env, jclass obj, jobject outRef, jlong repoPtr, jstring branchName, jlong annoCommitPtr, jint force);
-    static native int jniCreateFromAnnotated(AtomicLong outRef, long repoPtr, String branchName, long annoCommitPtr, int force);
+    //    /**int git_branch_create_from_annotated(git_reference **ref_out, git_repository
+    // *repository, const char *branch_name, const git_annotated_commit *commit, int force); */
+    //    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniCreateFromAnnotated)(JNIEnv *env, jclass
+    // obj, jobject outRef, jlong repoPtr, jstring branchName, jlong annoCommitPtr, jint force);
+    static native int jniCreateFromAnnotated(
+            AtomicLong outRef, long repoPtr, String branchName, long annoCommitPtr, int force);
     /**
      * Create a new branch pointing at a target commit
      *
-     * This behaves like `git_branch_create()` but takes an annotated
-     * commit, which lets you specify which extended sha syntax string was
-     * specified by a user, allowing for more exact reflog messages.
+     * <p>This behaves like `git_branch_create()` but takes an annotated commit, which lets you
+     * specify which extended sha syntax string was specified by a user, allowing for more exact
+     * reflog messages.
      *
-     * See the documentation for `git_branch_create()`.
+     * <p>See the documentation for `git_branch_create()`.
      *
      * @param repo repository from which the branch is created
      * @param branchName name of the branch to be created
@@ -45,38 +48,66 @@ public class Branch {
      * @return reference of the created branch
      * @throws GitException
      */
-    public static Reference createFromAnnotated(Repository repo, String branchName, AnnotatedCommit annotatedCommit, boolean force) {
+    public static Reference createFromAnnotated(
+            Repository repo, String branchName, AnnotatedCommit annotatedCommit, boolean force) {
         AtomicLong outRef = new AtomicLong();
-        Error.throwIfNeeded(jniCreateFromAnnotated(outRef, repo.getRawPointer(), branchName, annotatedCommit.getRawPointer(), force ? 1 : 0));
+        Error.throwIfNeeded(
+                jniCreateFromAnnotated(
+                        outRef,
+                        repo.getRawPointer(),
+                        branchName,
+                        annotatedCommit.getRawPointer(),
+                        force ? 1 : 0));
         return new Reference(outRef.get());
     }
-//    /**int git_branch_delete(git_reference *branch); */
-//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniDelete)(JNIEnv *env, jclass obj, jlong refPtr);
-//    /**int git_branch_iterator_new(git_branch_iterator **out, git_repository *repo, git_branch_t list_flags); */
-//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniIteratorNew)(JNIEnv *env, jclass obj, jobject outBranchIter, jlong repoPtr, jint listFlags);
-//    /**int git_branch_next(git_reference **out, git_branch_t *out_type, git_branch_iterator *iter); */
-//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniNext)(JNIEnv *env, jclass obj, jobject outRef, jobject outType, jlong branchIterPtr);
-//    /**void git_branch_iterator_free(git_branch_iterator *iter); */
-//    JNIEXPORT void JNICALL J_MAKE_METHOD(Branch_jniIteratorFree)(JNIEnv *env, jclass obj, jlong branchIterPtr);
-//    /**int git_branch_move(git_reference **out, git_reference *branch, const char *new_branch_name, int force); */
-//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniMove)(JNIEnv *env, jclass obj, jobject outRef, jlong branchPtr, jstring branchName, jint force);
-//    /**int git_branch_lookup(git_reference **out, git_repository *repo, const char *branch_name, git_branch_t branch_type); */
-//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniLookup)(JNIEnv *env, jclass obj, jobject outRef, jlong repoPtr, jstring branchName, jint branchType);
-//    /**int git_branch_name(const char **out, const git_reference *ref); */
-//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniName)(JNIEnv *env, jclass obj, jobject outStr, jlong refPtr);
-//    /**int git_branch_upstream(git_reference **out, const git_reference *branch); */
-//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniUpstream)(JNIEnv *env, jclass obj, jobject outRef, jlong branchPtr);
-//    /**int git_branch_set_upstream(git_reference *branch, const char *upstream_name); */
-//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniSetUpstream)(JNIEnv *env, jclass obj, jlong refPtr, jstring upstreamName);
-//    /**int git_branch_upstream_name(git_buf *out, git_repository *repo, const char *refname); */
-//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniUpstreamName)(JNIEnv *env, jclass obj, jobject outBuf, jlong repoPtr, jstring refName);
-//    /**int git_branch_is_head(const git_reference *branch); */
-//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniIsHead)(JNIEnv *env, jclass obj, jlong refPtr);
-//    /**int git_branch_is_checked_out(const git_reference *branch); */
-//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniIsCheckedOut)(JNIEnv *env, jclass obj, jlong rePftr);
-//    /**int git_branch_remote_name(git_buf *out, git_repository *repo, const char *canonical_branch_name); */
-//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniRemoteName)(JNIEnv *env, jclass obj, jobject outBuf, jlong repoPtr, jstring canonicalBranchName);
-//    /**int git_branch_upstream_remote(git_buf *buf, git_repository *repo, const char *refname); */
-//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniUpstreamRemote)(JNIEnv *env, jclass obj, jobject outBuf, jlong repoPtr, jstring refName);
+    //    /**int git_branch_delete(git_reference *branch); */
+    //    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniDelete)(JNIEnv *env, jclass obj, jlong
+    // refPtr);
+    //    /**int git_branch_iterator_new(git_branch_iterator **out, git_repository *repo,
+    // git_branch_t list_flags); */
+    //    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniIteratorNew)(JNIEnv *env, jclass obj,
+    // jobject outBranchIter, jlong repoPtr, jint listFlags);
+    //    /**int git_branch_next(git_reference **out, git_branch_t *out_type, git_branch_iterator
+    // *iter); */
+    //    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniNext)(JNIEnv *env, jclass obj, jobject
+    // outRef, jobject outType, jlong branchIterPtr);
+    //    /**void git_branch_iterator_free(git_branch_iterator *iter); */
+    //    JNIEXPORT void JNICALL J_MAKE_METHOD(Branch_jniIteratorFree)(JNIEnv *env, jclass obj,
+    // jlong branchIterPtr);
+    //    /**int git_branch_move(git_reference **out, git_reference *branch, const char
+    // *new_branch_name, int force); */
+    //    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniMove)(JNIEnv *env, jclass obj, jobject
+    // outRef, jlong branchPtr, jstring branchName, jint force);
+    //    /**int git_branch_lookup(git_reference **out, git_repository *repo, const char
+    // *branch_name, git_branch_t branch_type); */
+    //    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniLookup)(JNIEnv *env, jclass obj, jobject
+    // outRef, jlong repoPtr, jstring branchName, jint branchType);
+    //    /**int git_branch_name(const char **out, const git_reference *ref); */
+    //    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniName)(JNIEnv *env, jclass obj, jobject
+    // outStr, jlong refPtr);
+    //    /**int git_branch_upstream(git_reference **out, const git_reference *branch); */
+    //    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniUpstream)(JNIEnv *env, jclass obj, jobject
+    // outRef, jlong branchPtr);
+    //    /**int git_branch_set_upstream(git_reference *branch, const char *upstream_name); */
+    //    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniSetUpstream)(JNIEnv *env, jclass obj, jlong
+    // refPtr, jstring upstreamName);
+    //    /**int git_branch_upstream_name(git_buf *out, git_repository *repo, const char *refname);
+    // */
+    //    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniUpstreamName)(JNIEnv *env, jclass obj,
+    // jobject outBuf, jlong repoPtr, jstring refName);
+    //    /**int git_branch_is_head(const git_reference *branch); */
+    //    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniIsHead)(JNIEnv *env, jclass obj, jlong
+    // refPtr);
+    //    /**int git_branch_is_checked_out(const git_reference *branch); */
+    //    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniIsCheckedOut)(JNIEnv *env, jclass obj,
+    // jlong rePftr);
+    //    /**int git_branch_remote_name(git_buf *out, git_repository *repo, const char
+    // *canonical_branch_name); */
+    //    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniRemoteName)(JNIEnv *env, jclass obj,
+    // jobject outBuf, jlong repoPtr, jstring canonicalBranchName);
+    //    /**int git_branch_upstream_remote(git_buf *buf, git_repository *repo, const char
+    // *refname); */
+    //    JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniUpstreamRemote)(JNIEnv *env, jclass obj,
+    // jobject outBuf, jlong repoPtr, jstring refName);
 
 }

--- a/src/main/java/com/github/git24j/core/GitObject.java
+++ b/src/main/java/com/github/git24j/core/GitObject.java
@@ -65,8 +65,7 @@ public class GitObject implements AutoCloseable {
      */
     public static GitObject lookup(Repository repository, Oid oid, Type type) {
         AtomicLong outObj = new AtomicLong();
-        Error.throwIfNeeded(
-                jniLookup(outObj, repository.getRawPointer(), oid, type.value));
+        Error.throwIfNeeded(jniLookup(outObj, repository.getRawPointer(), oid, type.value));
         return GitObject.create(outObj.get());
     }
 
@@ -84,8 +83,7 @@ public class GitObject implements AutoCloseable {
     public static GitObject lookupPrefix(Repository repository, Oid oid, int len, Type type) {
         AtomicLong outObj = new AtomicLong();
         Error.throwIfNeeded(
-                jniLookupPrefix(
-                        outObj, repository.getRawPointer(), oid, len, type.value));
+                jniLookupPrefix(outObj, repository.getRawPointer(), oid, len, type.value));
         return GitObject.create(outObj.get());
     }
 

--- a/src/main/java/com/github/git24j/core/Oid.java
+++ b/src/main/java/com/github/git24j/core/Oid.java
@@ -1,8 +1,6 @@
 package com.github.git24j.core;
 
-import java.util.Arrays;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicLong;
 
 // TODO: change this class to immutable java object
 public class Oid {
@@ -12,11 +10,12 @@ public class Oid {
 
     /** in case of short sha, only up to {@code eSize} bytes are effective */
     private int eSize = RAWSZ;
+
     private byte[] id = new byte[RAWSZ];
 
-    Oid() { }
+    Oid() {}
 
-    Oid(byte []bytes) {
+    Oid(byte[] bytes) {
         eSize = bytes.length;
         System.arraycopy(bytes, 0, this.id, 0, eSize);
     }
@@ -28,10 +27,6 @@ public class Oid {
     public static Oid of(String hexSha) {
         byte[] bytes = hexStringToByteArray(hexSha.toLowerCase());
         return new Oid(bytes);
-    }
-
-    public boolean isShortId() {
-        return getEffectiveSize() < RAWSZ;
     }
 
     private static String bytesToHex(byte[] bytes, int len) {
@@ -61,6 +56,10 @@ public class Oid {
         return data;
     }
 
+    public boolean isShortId() {
+        return getEffectiveSize() < RAWSZ;
+    }
+
     public byte[] getId() {
         return id;
     }
@@ -75,8 +74,8 @@ public class Oid {
     }
 
     /**
-     * Get effective size of the oid. Normally, it should be {@code RAWSZ} but can
-     * be smaller in case of short sha.
+     * Get effective size of the oid. Normally, it should be {@code RAWSZ} but can be smaller in
+     * case of short sha.
      */
     public int getEffectiveSize() {
         return eSize;
@@ -94,7 +93,7 @@ public class Oid {
         if (eSize != oid.eSize) {
             return false;
         }
-        for (int i = 0; i <eSize; i++) {
+        for (int i = 0; i < eSize; i++) {
             if (id[i] != oid.id[i]) {
                 return false;
             }

--- a/src/main/java/com/github/git24j/core/Repository.java
+++ b/src/main/java/com/github/git24j/core/Repository.java
@@ -8,9 +8,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class Repository implements AutoCloseable {
-    /**
-     * C Pointer.
-     */
+    /** C Pointer. */
     private final AtomicLong _rawPtr = new AtomicLong();
 
     Repository(long rawPtr) {
@@ -124,10 +122,10 @@ public class Repository implements AutoCloseable {
     /**
      * Creates a new Git repository in the given folder.
      *
-     * @param path   the path to the repository
+     * @param path the path to the repository
      * @param isBare if true, a Git repository without a working directory is created at the pointed
-     *               path. If false, provided path will be considered as the working directory into which the
-     *               .git directory will be created.
+     *     path. If false, provided path will be considered as the working directory into which the
+     *     .git directory will be created.
      * @return repo just initialized.
      * @throws GitException git error.
      */
@@ -141,7 +139,7 @@ public class Repository implements AutoCloseable {
     /**
      * Create a new Git repository in the given folder with extended controls.
      *
-     * @param path     The path to the repository.
+     * @param path The path to the repository.
      * @param initOpts {@code InitOptions}
      * @return Repo just created or reinitialized.
      * @throws GitException git error
@@ -155,14 +153,14 @@ public class Repository implements AutoCloseable {
     /**
      * Find and open a repository with extended controls.
      *
-     * @param path        Path to open as git repository. If the flags permit "searching", then this can be
-     *                    a path to a subdirectory inside the working directory of the repository. May be NULL if
-     *                    flags is GIT_REPOSITORY_OPEN_FROM_ENV.
-     * @param flags       A combination of the OpenFlag flags.
+     * @param path Path to open as git repository. If the flags permit "searching", then this can be
+     *     a path to a subdirectory inside the working directory of the repository. May be NULL if
+     *     flags is GIT_REPOSITORY_OPEN_FROM_ENV.
+     * @param flags A combination of the OpenFlag flags.
      * @param ceilingDirs A GIT_PATH_LIST_SEPARATOR delimited list of path prefixes at which the
-     *                    search for a containing repository should terminate.
+     *     search for a containing repository should terminate.
      * @return repo just opened. This can actually be NULL if you only want to use the error code to
-     * see if a repo at this path could be opened.
+     *     see if a repo at this path could be opened.
      * @throws GitException git error.
      */
     public static Repository openExt(String path, EnumSet<OpenFlag> flags, String ceilingDirs) {
@@ -207,9 +205,9 @@ public class Repository implements AutoCloseable {
     /**
      * Set the path to the working directory for this repository
      *
-     * @param path          The path to a working directory
+     * @param path The path to a working directory
      * @param updateGitLink Create/update gitlink in workdir and set config "core.worktree" (if
-     *                      workdir is not the parent of the .git directory)
+     *     workdir is not the parent of the .git directory)
      * @throws GitException git error
      */
     public void setWorkdir(Path path, boolean updateGitLink) {
@@ -344,12 +342,12 @@ public class Repository implements AutoCloseable {
     /**
      * Calculate hash of file using repository filtering rules.
      *
-     * @param path   Path to file on disk whose contents should be hashed. If the repository is not
-     *               NULL, this can be a relative path.
-     * @param type   The object type to hash as (e.g. GIT_OBJECT_BLOB)
+     * @param path Path to file on disk whose contents should be hashed. If the repository is not
+     *     NULL, this can be a relative path.
+     * @param type The object type to hash as (e.g. GIT_OBJECT_BLOB)
      * @param asPath The path to use to look up filtering rules. If this is NULL, then the `path`
-     *               parameter will be used instead. If this is passed as the empty string, then no filters
-     *               will be applied when calculating the hash.
+     *     parameter will be used instead. If this is passed as the empty string, then no filters
+     *     will be applied when calculating the hash.
      * @return Output value of calculated SHA
      * @throws GitException git errors
      */
@@ -379,9 +377,7 @@ public class Repository implements AutoCloseable {
         Error.throwIfNeeded(jniSetHeadDetached(getRawPointer(), oid));
     }
 
-    /**
-     * Detach the HEAD.
-     */
+    /** Detach the HEAD. */
     public void detachHead() {
         Error.throwIfNeeded(jniDetachHead(getRawPointer()));
     }
@@ -416,16 +412,14 @@ public class Repository implements AutoCloseable {
      * <p>This namespace affects all reference operations for the repo. See `man gitnamespaces`
      *
      * @param namespace The namespace. This should not include the refs folder, e.g. to namespace
-     *                  all references under `refs/namespaces/foo/`, use `foo` as the namespace.
+     *     all references under `refs/namespaces/foo/`, use `foo` as the namespace.
      * @throws GitException git error
      */
     public void setNamespace(String namespace) {
         Error.throwIfNeeded(jniSetNamespace(getRawPointer(), namespace));
     }
 
-    /**
-     * Determine if the repository was a shallow clone.
-     */
+    /** Determine if the repository was a shallow clone. */
     public boolean isShadow() {
         return jniIsShadow(getRawPointer()) == 1;
     }
@@ -443,7 +437,7 @@ public class Repository implements AutoCloseable {
     /**
      * Set the identity to be used for writing reflogs
      *
-     * @param name  the name to use for the reflog entries
+     * @param name the name to use for the reflog entries
      * @param email the email to use for the reflog entries
      * @throws GitException git error
      */
@@ -470,9 +464,7 @@ public class Repository implements AutoCloseable {
         free();
     }
 
-    /**
-     * Close the repository, no-op if not opened.
-     */
+    /** Close the repository, no-op if not opened. */
     public void free() {
         jniFree(_rawPtr.get());
         _rawPtr.set(0);
@@ -773,8 +765,8 @@ public class Repository implements AutoCloseable {
          * Callback used to iterate over each FETCH_HEAD entry
          *
          * @param remoteUrl The remote URL
-         * @param oid       The reference target OID
-         * @param isMerge   Was the reference the result of a merge
+         * @param oid The reference target OID
+         * @param isMerge Was the reference the result of a merge
          * @return non-zero to terminate the iteration
          */
         public abstract int call(String remoteUrl, Oid oid, boolean isMerge);

--- a/src/main/java/com/github/git24j/core/Revparse.java
+++ b/src/main/java/com/github/git24j/core/Revparse.java
@@ -79,9 +79,6 @@ public class Revparse {
             if (obj != null) {
                 obj.close();
             }
-            if (ref != null) {
-                ref.close();
-            }
         }
 
         /** single object found from rev parsing. */

--- a/src/test/java/com/github/git24j/core/RepositoryTest.java
+++ b/src/test/java/com/github/git24j/core/RepositoryTest.java
@@ -66,9 +66,8 @@ public class RepositoryTest extends TestBase {
     public void headForWorkTree() {
         Path path = TestRepo.WORKTREE1.tempCopy(folder);
         try (Repository repository = Repository.open(path.toString())) {
-            try (Reference ref = repository.headForWorkTree("wt1")) {
-                Assert.assertTrue(ref.getRawPointer() > 0);
-            }
+            Reference ref = repository.headForWorkTree("wt1");
+            Assert.assertTrue(ref.getRawPointer() > 0);
         }
     }
 


### PR DESCRIPTION
Reference and GitObject are internal objects (no external resources are owned). There is no need to GC them eagerly. Their c-conterparty should have the same lifecycle as their java objects.