### PR TITLE
Move variable definition to .c files

### DIFF
--- a/src/main/c/git24j/j_libgit2.c
+++ b/src/main/c/git24j/j_libgit2.c
@@ -7,6 +7,8 @@
 
 extern j_constants_t *jniConstants;
 
+JavaVM *globalJvm;
+
 jclass j_find_and_hold_clz(JNIEnv *env, const char *descriptor)
 {
     jclass clz = (*env)->FindClass(env, descriptor);

--- a/src/main/c/git24j/j_libgit2.h
+++ b/src/main/c/git24j/j_libgit2.h
@@ -10,7 +10,7 @@ extern "C"
 #endif
     jclass j_find_and_hold_clz(JNIEnv *env, const char *descriptor);
 
-    JavaVM *globalJvm;
+    extern JavaVM *globalJvm;
 
     JNIEXPORT void JNICALL J_MAKE_METHOD(Libgit2_init)(JNIEnv *, jclass);
 

--- a/src/main/c/git24j/j_mappers.c
+++ b/src/main/c/git24j/j_mappers.c
@@ -8,6 +8,8 @@
 
 extern JavaVM *globalJvm;
 
+j_constants_t *jniConstants;
+
 /** Retrieve env attached to the current thread. */
 JNIEnv *getEnv(void)
 {

--- a/src/main/c/git24j/j_mappers.h
+++ b/src/main/c/git24j/j_mappers.h
@@ -65,7 +65,7 @@ extern "C"
     } j_constants_t;
 
     /** commonly used constants. */
-    j_constants_t *jniConstants;
+    extern j_constants_t *jniConstants;
 
     /** Retrieve env attached to the current thread. */
     JNIEnv *getEnv(void);


### PR DESCRIPTION
ANSI-c allows declaring varialbes multiple times, but define once. 

Previously jniConstants and globalJVM was defined once in the header. That caused problem if the header file is imported multiple times.

This change move the definition to .c file and keep the declarition in the .h file