### PR TITLE
adapt libgit2 1.9.0, fix bugs, update version to 1.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </properties>
     <groupId>com.github.git24j</groupId>
     <artifactId>git24j</artifactId>
-    <version>1.0.1.20240124</version>
+    <version>1.0.2.20240423</version>
     <packaging>jar</packaging>
     <name>git24j</name>
     <description>A java bindings of the libgit2 project.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </properties>
     <groupId>com.github.git24j</groupId>
     <artifactId>git24j</artifactId>
-    <version>1.0.3.20241022</version>
+    <version>1.0.4.20241114</version>
     <packaging>jar</packaging>
     <name>git24j</name>
     <description>A java bindings of the libgit2 project.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </properties>
     <groupId>com.github.git24j</groupId>
     <artifactId>git24j</artifactId>
-    <version>1.0.4.20241114</version>
+    <version>1.9.0</version>
     <packaging>jar</packaging>
     <name>git24j</name>
     <description>A java bindings of the libgit2 project.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </properties>
     <groupId>com.github.git24j</groupId>
     <artifactId>git24j</artifactId>
-    <version>1.0.2.20240423</version>
+    <version>1.0.3.20241022</version>
     <packaging>jar</packaging>
     <name>git24j</name>
     <description>A java bindings of the libgit2 project.</description>

--- a/src/main/c/git24j/j_annotated_commit.c
+++ b/src/main/c/git24j/j_annotated_commit.c
@@ -5,16 +5,16 @@
 extern j_constants_t *jniConstants;
 
 /** int git_annotated_commit_from_ref(git_annotated_commit **out, git_repository *repo, const git_reference *ref); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniFromRef)(JNIEnv *env, jclass obj, jobject outAc, long repoPtr, long refPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniFromRef)(JNIEnv *env, jclass obj, jobject outAc, jlong repoPtr, jlong refPtr)
 {
     git_annotated_commit *c_ac = 0;
     int e = git_annotated_commit_from_ref(&c_ac, (git_repository *)repoPtr, (git_reference *)refPtr);
-    (*env)->CallVoidMethod(env, outAc, jniConstants->midAtomicLongSet, (long)c_ac);
+    (*env)->CallVoidMethod(env, outAc, jniConstants->midAtomicLongSet, (jlong)c_ac);
     return e;
 }
 
 /** int git_annotated_commit_from_fetchhead(git_annotated_commit **out, git_repository *repo, const char *branch_name, const char *remote_url, const git_oid *id); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniFromFetchHead)(JNIEnv *env, jclass obj, jobject outAc, long repoPtr, jstring branchName, jstring remoteUrl, jobject oid)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniFromFetchHead)(JNIEnv *env, jclass obj, jobject outAc, jlong repoPtr, jstring branchName, jstring remoteUrl, jobject oid)
 {
     assert(repoPtr && branchName && remoteUrl && oid && "bad user input");
     git_annotated_commit *c_ac = 0;
@@ -23,30 +23,30 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniFromFetchHead)(JNIEnv *e
     git_oid c_oid;
     j_git_oid_from_java(env, oid, &c_oid);
     int e = git_annotated_commit_from_fetchhead(&c_ac, (git_repository *)repoPtr, branch_name, remote_url, &c_oid);
-    (*env)->CallVoidMethod(env, outAc, jniConstants->midAtomicLongSet, (long)c_ac);
+    (*env)->CallVoidMethod(env, outAc, jniConstants->midAtomicLongSet, (jlong)c_ac);
     free(branch_name);
     free(remote_url);
     return e;
 }
 
 /** int git_annotated_commit_lookup(git_annotated_commit **out, git_repository *repo, const git_oid *id); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniLookup)(JNIEnv *env, jclass obj, jobject outAc, long repoPtr, jobject oid)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniLookup)(JNIEnv *env, jclass obj, jobject outAc, jlong repoPtr, jobject oid)
 {
     git_annotated_commit *c_out = 0;
     git_oid c_oid;
     j_git_oid_from_java(env, oid, &c_oid);
     int e = git_annotated_commit_lookup(&c_out, (git_repository *)repoPtr, &c_oid);
-    (*env)->CallVoidMethod(env, outAc, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outAc, jniConstants->midAtomicLongSet, (jlong)c_out);
     return e;
 }
 
 /** int git_annotated_commit_from_revspec(git_annotated_commit **out, git_repository *repo, const char *revspec); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniFromRevspec)(JNIEnv *env, jclass obj, jobject outAc, long repoPtr, jstring revspec)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniFromRevspec)(JNIEnv *env, jclass obj, jobject outAc, jlong repoPtr, jstring revspec)
 {
     git_annotated_commit *c_out = 0;
     char *c_revspec = j_copy_of_jstring(env, revspec, false);
     int e = git_annotated_commit_from_revspec(&c_out, (git_repository *)repoPtr, c_revspec);
-    (*env)->CallVoidMethod(env, outAc, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outAc, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_revspec);
     return e;
 }

--- a/src/main/c/git24j/j_annotated_commit.h
+++ b/src/main/c/git24j/j_annotated_commit.h
@@ -10,13 +10,13 @@ extern "C"
 #endif
 
     /** int git_annotated_commit_from_ref(git_annotated_commit **out, git_repository *repo, const git_reference *ref); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniFromRef)(JNIEnv *env, jclass obj, jobject outAc, long repoPtr, long refPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniFromRef)(JNIEnv *env, jclass obj, jobject outAc, jlong repoPtr, jlong refPtr);
     /** int git_annotated_commit_from_fetchhead(git_annotated_commit **out, git_repository *repo, const char *branch_name, const char *remote_url, const git_oid *id); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniFromFetchHead)(JNIEnv *env, jclass obj, jobject outAc, long repoPtr, jstring branchName, jstring remoteUrl, jobject oid);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniFromFetchHead)(JNIEnv *env, jclass obj, jobject outAc, jlong repoPtr, jstring branchName, jstring remoteUrl, jobject oid);
     /** int git_annotated_commit_lookup(git_annotated_commit **out, git_repository *repo, const git_oid *id); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniLookup)(JNIEnv *env, jclass obj, jobject outAc, long repoPtr, jobject oid);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniLookup)(JNIEnv *env, jclass obj, jobject outAc, jlong repoPtr, jobject oid);
     /** int git_annotated_commit_from_revspec(git_annotated_commit **out, git_repository *repo, const char *revspec); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniFromRevspec)(JNIEnv *env, jclass obj, jobject outAc, long repoPtr, jstring revspec);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(AnnotatedCommit_jniFromRevspec)(JNIEnv *env, jclass obj, jobject outAc, jlong repoPtr, jstring revspec);
     /** const git_oid * git_annotated_commit_id(const git_annotated_commit *commit); */
     JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(AnnotatedCommit_jniId)(JNIEnv *env, jclass obj, jlong acPtr);
     /** const char * git_annotated_commit_ref(const git_annotated_commit *commit); */

--- a/src/main/c/git24j/j_apply.c
+++ b/src/main/c/git24j/j_apply.c
@@ -38,7 +38,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Apply_jniToTree)(JNIEnv *env, jclass obj, j
 {
     git_index *c_out;
     int r = git_apply_to_tree(&c_out, (git_repository *)repoPtr, (git_tree *)preimagePtr, (git_diff *)diffPtr, (git_apply_options *)optionsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -54,7 +54,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Apply_jniOptionsNew)(JNIEnv *env, jclass ob
 {
     git_apply_options *opts = (git_apply_options *)malloc(sizeof(git_apply_options));
     int e = git_apply_options_init(opts, (unsigned int)version);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)opts);
     j_cb_payload *payload = (j_cb_payload *)malloc(sizeof(j_cb_payload) * 2);
 
     j_cb_payload_init(env, &payload[0], deltaCb, "(J)I");

--- a/src/main/c/git24j/j_blame.c
+++ b/src/main/c/git24j/j_blame.c
@@ -10,10 +10,24 @@ extern j_constants_t *jniConstants;
 
 /** -------- Wrapper Body ---------- */
 /** int git_blame_init_options(git_blame_options *opts, unsigned int version); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniInitOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jint version)
+//JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniInitOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jint version)
+//{
+//    int r = git_blame_init_options((git_blame_options *)optsPtr, version);
+//    return r;
+//}
+
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniOptionsNew)(JNIEnv *env, jclass obj, jobject outPtr, jint version)
 {
-    int r = git_blame_init_options((git_blame_options *)optsPtr, version);
-    return r;
+    git_blame_options *opts = (git_blame_options *)malloc(sizeof(git_blame_options));
+
+    //value of `err`: Zero on success; -1 on failure.
+    // I am not sure it can get this err msg from git_last_err(), if version bad, maybe can get, if mem alloc err, maybe can't
+    int initErr = git_blame_init_options(opts, (unsigned int)version);
+
+    // this set no check the initErr, even initErr, still set the ptr to java pointer, it make java be able free the mallocated memory
+    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)opts);
+
+    return initErr;
 }
 
 /** size_t git_blame_get_hunk_count(git_blame *blame); */

--- a/src/main/c/git24j/j_blame.c
+++ b/src/main/c/git24j/j_blame.c
@@ -43,7 +43,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniFile)(JNIEnv *env, jclass obj, job
     git_blame *c_out = NULL;
     char *c_path = j_copy_of_jstring(env, path, true);
     int r = git_blame_file(&c_out, (git_repository *)repoPtr, c_path, (git_blame_options *)optionsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_blame_free(c_out); */
     free(c_path);
     return r;
@@ -55,7 +55,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniBuffer)(JNIEnv *env, jclass obj, j
     git_blame *c_out = NULL;
     char *c_buffer = j_copy_of_jstring(env, buffer, true);
     int r = git_blame_buffer(&c_out, (git_blame *)referencePtr, c_buffer, bufferLen);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_blame_free(c_out); */
     free(c_buffer);
     return r;

--- a/src/main/c/git24j/j_blame.h
+++ b/src/main/c/git24j/j_blame.h
@@ -10,8 +10,8 @@ extern "C"
 #endif
 
     /** int git_blame_init_options(git_blame_options *opts, unsigned int version); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniInitOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jint version);
-    JNIEXPORT void JNICALL J_MAKE_METHOD(Blame_jniOptionsNew)(JNIEnv *env, jclass obj, jobject outPtr, jint version);
+//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniInitOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jint version);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniOptionsNew)(JNIEnv *env, jclass obj, jobject outPtr, jint version);
 
     /** size_t git_blame_get_hunk_count(git_blame *blame); */
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniGetHunkCount)(JNIEnv *env, jclass obj, jlong blamePtr);

--- a/src/main/c/git24j/j_blob.c
+++ b/src/main/c/git24j/j_blob.c
@@ -4,18 +4,18 @@
 extern j_constants_t *jniConstants;
 
 /** int git_blob_lookup(git_blob **blob, git_repository *repo, const git_oid *id); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniLookup)(JNIEnv *env, jclass obj, jobject outBlob, long repoPtr, jobject oid)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniLookup)(JNIEnv *env, jclass obj, jobject outBlob, jlong repoPtr, jobject oid)
 {
     git_blob *c_blob;
     git_oid c_oid;
     j_git_oid_from_java(env, oid, &c_oid);
     int e = git_blob_lookup(&c_blob, (git_repository *)repoPtr, &c_oid);
-    (*env)->CallVoidMethod(env, outBlob, jniConstants->midAtomicLongSet, (long)c_blob);
+    (*env)->CallVoidMethod(env, outBlob, jniConstants->midAtomicLongSet, (jlong)c_blob);
     return e;
 }
 
 /** int git_blob_lookup_prefix(git_blob **blob, git_repository *repo, const git_oid *id, size_t len); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniLookupPrefix)(JNIEnv *env, jclass obj, jobject outBlob, long repoPtr, jstring shortId)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniLookupPrefix)(JNIEnv *env, jclass obj, jobject outBlob, jlong repoPtr, jstring shortId)
 {
     git_blob *c_blob = 0;
     git_oid c_oid;
@@ -27,43 +27,43 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniLookupPrefix)(JNIEnv *env, jclass o
     }
 
     int r = git_blob_lookup_prefix(&c_blob, (git_repository *)repoPtr, &c_oid, short_id_len);
-    (*env)->CallVoidMethod(env, outBlob, jniConstants->midAtomicLongSet, (long)c_blob);
+    (*env)->CallVoidMethod(env, outBlob, jniConstants->midAtomicLongSet, (jlong)c_blob);
     return r;
 }
 
 /** void git_blob_free(git_blob *blob); */
-JNIEXPORT void JNICALL J_MAKE_METHOD(Blob_jniFree)(JNIEnv *env, jclass obj, long blobPtr)
+JNIEXPORT void JNICALL J_MAKE_METHOD(Blob_jniFree)(JNIEnv *env, jclass obj, jlong blobPtr)
 {
     git_blob_free((git_blob *)blobPtr);
 }
 
 /** const git_oid * git_blob_id(const git_blob *blob); */
-JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Blob_jniId)(JNIEnv *env, jclass obj, long blobPtr)
+JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Blob_jniId)(JNIEnv *env, jclass obj, jlong blobPtr)
 {
     const git_oid *c_oid = git_blob_id((git_blob *)blobPtr);
     return j_git_oid_to_bytearray(env, c_oid);
 }
 
 /** git_repository * git_blob_owner(const git_blob *blob); */
-JNIEXPORT jlong JNICALL J_MAKE_METHOD(Blob_jniOwner)(JNIEnv *env, jclass obj, long blobPtr)
+JNIEXPORT jlong JNICALL J_MAKE_METHOD(Blob_jniOwner)(JNIEnv *env, jclass obj, jlong blobPtr)
 {
     return (jlong)git_blob_owner((git_blob *)blobPtr);
 }
 
 /** const void * git_blob_rawcontent(const git_blob *blob); */
-JNIEXPORT jlong JNICALL J_MAKE_METHOD(Blob_jniRawContent)(JNIEnv *env, jclass obj, long blobPtr)
+JNIEXPORT jlong JNICALL J_MAKE_METHOD(Blob_jniRawContent)(JNIEnv *env, jclass obj, jlong blobPtr)
 {
     return (jlong)git_blob_rawcontent((git_blob *)blobPtr);
 }
 
 /** git_off_t git_blob_rawsize(const git_blob *blob); */
-JNIEXPORT jlong JNICALL J_MAKE_METHOD(Blob_jniRawSize)(JNIEnv *env, jclass obj, long blobPtr)
+JNIEXPORT jlong JNICALL J_MAKE_METHOD(Blob_jniRawSize)(JNIEnv *env, jclass obj, jlong blobPtr)
 {
     return (jlong)git_blob_rawsize((git_blob *)blobPtr);
 }
 
 /** int git_blob_create_from_workdir(git_oid *id, git_repository *repo, const char *relative_path); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromWorkdir)(JNIEnv *env, jclass obj, jobject outId, long repoPtr, jstring relativePath)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromWorkdir)(JNIEnv *env, jclass obj, jobject outId, jlong repoPtr, jstring relativePath)
 {
     git_oid c_oid;
     char *relative_path = j_copy_of_jstring(env, relativePath, true);
@@ -74,7 +74,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromWorkdir)(JNIEnv *env, jcl
 }
 
 /** int git_blob_create_from_disk(git_oid *id, git_repository *repo, const char *path); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromDisk)(JNIEnv *env, jclass obj, jobject outId, long repoPtr, jstring path)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromDisk)(JNIEnv *env, jclass obj, jobject outId, jlong repoPtr, jstring path)
 {
     git_oid c_oid;
     char *c_path = j_copy_of_jstring(env, path, true);
@@ -85,18 +85,18 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromDisk)(JNIEnv *env, jclass
 }
 
 /** int git_blob_create_from_stream(git_writestream **out, git_repository *repo, const char *hintpath); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromStream)(JNIEnv *env, jclass obj, jobject outStream, long repoPtr, jstring hintPath)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromStream)(JNIEnv *env, jclass obj, jobject outStream, jlong repoPtr, jstring hintPath)
 {
     char *hint_path = j_copy_of_jstring(env, hintPath, true);
     git_writestream *out_stream = 0;
     int e = git_blob_create_fromstream(&out_stream, (git_repository *)repoPtr, hint_path);
-    (*env)->CallVoidMethod(env, outStream, jniConstants->midAtomicLongSet, (long)out_stream);
+    (*env)->CallVoidMethod(env, outStream, jniConstants->midAtomicLongSet, (jlong)out_stream);
     free(hint_path);
     return e;
 }
 
 /** int git_blob_create_from_stream_commit(git_oid *out, git_writestream *stream); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromStreamCommit)(JNIEnv *env, jclass obj, jobject outId, long streamPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromStreamCommit)(JNIEnv *env, jclass obj, jobject outId, jlong streamPtr)
 {
     git_oid c_oid;
     int e = git_blob_create_fromstream_commit(&c_oid, (git_writestream *)streamPtr);
@@ -105,7 +105,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromStreamCommit)(JNIEnv *env
 }
 
 /** int git_blob_create_from_buffer(git_oid *id, git_repository *repo, const void *buffer, size_t len); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromBuffer)(JNIEnv *env, jclass obj, jobject outId, long repoPtr, jbyteArray buf)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromBuffer)(JNIEnv *env, jclass obj, jobject outId, jlong repoPtr, jbyteArray buf)
 {
     git_oid c_oid;
     int c_buf_len;
@@ -117,7 +117,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromBuffer)(JNIEnv *env, jcla
 }
 
 /** int git_blob_is_binary(const git_blob *blob); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniIsBinary)(JNIEnv *env, jclass obj, long blobPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniIsBinary)(JNIEnv *env, jclass obj, jlong blobPtr)
 {
     return git_blob_is_binary((git_blob *)blobPtr);
 }
@@ -127,7 +127,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniDup)(JNIEnv *env, jclass obj, jobje
 {
     git_blob *out = 0;
     int e = git_blob_dup(&out, (git_blob *)srcPtr);
-    (*env)->CallVoidMethod(env, outDest, jniConstants->midAtomicLongSet, (long)out);
+    (*env)->CallVoidMethod(env, outDest, jniConstants->midAtomicLongSet, (jlong)out);
     return e;
 }
 

--- a/src/main/c/git24j/j_blob.h
+++ b/src/main/c/git24j/j_blob.h
@@ -10,42 +10,42 @@ extern "C"
 #endif
 
     /** int git_blob_lookup(git_blob **blob, git_repository *repo, const git_oid *id); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniLookup)(JNIEnv *env, jclass obj, jobject outBlob, long repoPtr, jobject oid);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniLookup)(JNIEnv *env, jclass obj, jobject outBlob, jlong repoPtr, jobject oid);
 
     /** int git_blob_lookup_prefix(git_blob **blob, git_repository *repo, const git_oid *id, size_t len); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniLookupPrefix)(JNIEnv *env, jclass obj, jobject outBlob, long repoPtr, jstring shortId);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniLookupPrefix)(JNIEnv *env, jclass obj, jobject outBlob, jlong repoPtr, jstring shortId);
     /** void git_blob_free(git_blob *blob); */
-    JNIEXPORT void JNICALL J_MAKE_METHOD(Blob_jniFree)(JNIEnv *env, jclass obj, long blobPtr);
+    JNIEXPORT void JNICALL J_MAKE_METHOD(Blob_jniFree)(JNIEnv *env, jclass obj, jlong blobPtr);
 
     /** const git_oid * git_blob_id(const git_blob *blob); */
-    JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Blob_jniId)(JNIEnv *env, jclass obj, long blobPtr);
+    JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Blob_jniId)(JNIEnv *env, jclass obj, jlong blobPtr);
 
     /** git_repository * git_blob_owner(const git_blob *blob); */
-    JNIEXPORT jlong JNICALL J_MAKE_METHOD(Blob_jniOwner)(JNIEnv *env, jclass obj, long blobPtr);
+    JNIEXPORT jlong JNICALL J_MAKE_METHOD(Blob_jniOwner)(JNIEnv *env, jclass obj, jlong blobPtr);
 
     /** const void * git_blob_rawcontent(const git_blob *blob); */
-    JNIEXPORT jlong JNICALL J_MAKE_METHOD(Blob_jniRawContent)(JNIEnv *env, jclass obj, long blobPtr);
+    JNIEXPORT jlong JNICALL J_MAKE_METHOD(Blob_jniRawContent)(JNIEnv *env, jclass obj, jlong blobPtr);
 
     /** git_off_t git_blob_rawsize(const git_blob *blob); */
-    JNIEXPORT jlong JNICALL J_MAKE_METHOD(Blob_jniRawSize)(JNIEnv *env, jclass obj, long blobPtr);
+    JNIEXPORT jlong JNICALL J_MAKE_METHOD(Blob_jniRawSize)(JNIEnv *env, jclass obj, jlong blobPtr);
 
     /** int git_blob_create_from_workdir(git_oid *id, git_repository *repo, const char *relative_path); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromWorkdir)(JNIEnv *env, jclass obj, jobject outId, long repoPtr, jstring relativePath);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromWorkdir)(JNIEnv *env, jclass obj, jobject outId, jlong repoPtr, jstring relativePath);
 
     /** int git_blob_create_from_disk(git_oid *id, git_repository *repo, const char *path); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromDisk)(JNIEnv *env, jclass obj, jobject outId, long repoPtr, jstring path);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromDisk)(JNIEnv *env, jclass obj, jobject outId, jlong repoPtr, jstring path);
 
     /** int git_blob_create_from_stream(git_writestream **out, git_repository *repo, const char *hintpath); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromStream)(JNIEnv *env, jclass obj, jobject outStream, long repoPtr, jstring hintPath);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromStream)(JNIEnv *env, jclass obj, jobject outStream, jlong repoPtr, jstring hintPath);
 
     /** int git_blob_create_from_stream_commit(git_oid *out, git_writestream *stream); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromStreamCommit)(JNIEnv *env, jclass obj, jobject outId, long streamPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromStreamCommit)(JNIEnv *env, jclass obj, jobject outId, jlong streamPtr);
 
     /** int git_blob_create_from_buffer(git_oid *id, git_repository *repo, const void *buffer, size_t len); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromBuffer)(JNIEnv *env, jclass obj, jobject outId, long repoPtr, jbyteArray buf);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniCreateFromBuffer)(JNIEnv *env, jclass obj, jobject outId, jlong repoPtr, jbyteArray buf);
 
     /** int git_blob_is_binary(const git_blob *blob); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniIsBinary)(JNIEnv *env, jclass obj, long blobPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniIsBinary)(JNIEnv *env, jclass obj, jlong blobPtr);
 
     /** int git_blob_dup(git_blob **out, git_blob *source); */
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Blob_jniDup)(JNIEnv *env, jclass obj, jobject outDest, jlong srcPtr);

--- a/src/main/c/git24j/j_branch.c
+++ b/src/main/c/git24j/j_branch.c
@@ -15,7 +15,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniCreate)(JNIEnv *env, jclass obj, 
     char *c_branch_name = j_copy_of_jstring(env, branchName, false);
     int error = git_branch_create(&c_ref, (git_repository *)repoPtr, c_branch_name, (const git_commit *)targetPtr, force);
     free(c_branch_name);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_ref);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_ref);
     return error;
 }
 
@@ -25,7 +25,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniCreateFromAnnotated)(JNIEnv *env,
     git_reference *c_ref = 0;
     char *branch_name = j_copy_of_jstring(env, branchName, false);
     int e = git_branch_create_from_annotated(&c_ref, (git_repository *)repoPtr, branch_name, (git_annotated_commit *)annoCommitPtr, force);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_ref);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_ref);
     free(branch_name);
     return e;
 }
@@ -41,7 +41,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniIteratorNew)(JNIEnv *env, jclass 
 {
     git_branch_iterator *c_branch_iter = 0;
     int e = git_branch_iterator_new(&c_branch_iter, (git_repository *)repoPtr, (git_branch_t)listFlags);
-    (*env)->CallVoidMethod(env, outBranchIter, jniConstants->midAtomicLongSet, (long)c_branch_iter);
+    (*env)->CallVoidMethod(env, outBranchIter, jniConstants->midAtomicLongSet, (jlong)c_branch_iter);
     return e;
 }
 
@@ -52,7 +52,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniNext)(JNIEnv *env, jclass obj, jo
     git_reference *c_out_ref = 0;
     git_branch_t c_out_branch_type;
     int e = git_branch_next(&c_out_ref, &c_out_branch_type, (git_branch_iterator *)branchIterPtr);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_out_ref);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_out_ref);
     jclass jclz = (*env)->GetObjectClass(env, outType);
     assert(jclz && "Could not find outType class from given outType object");
     j_call_setter_int(env, jclz, outType, "set", (jint)c_out_branch_type);
@@ -72,7 +72,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniMove)(JNIEnv *env, jclass obj, jo
     git_reference *c_out_ref = 0;
     char *branch_name = j_copy_of_jstring(env, branchName, false);
     int e = git_branch_move(&c_out_ref, (git_reference *)branchPtr, branch_name, force);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_out_ref);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_out_ref);
     free(branch_name);
     return e;
 }
@@ -82,7 +82,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniLookup)(JNIEnv *env, jclass obj, 
     git_reference *c_out_ref = 0;
     char *branch_name = j_copy_of_jstring(env, branchName, false);
     int e = git_branch_lookup(&c_out_ref, (git_repository *)repoPtr, branch_name, (git_branch_t)branchType);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_out_ref);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_out_ref);
     free(branch_name);
     return e;
 }
@@ -106,7 +106,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Branch_jniUpstream)(JNIEnv *env, jclass obj
 {
     git_reference *out_ref = 0;
     int e = git_branch_upstream(&out_ref, (git_reference *)branchPtr);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)out_ref);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)out_ref);
     return e;
 }
 /**int git_branch_set_upstream(git_reference *branch, const char *upstream_name); */

--- a/src/main/c/git24j/j_checkout.c
+++ b/src/main/c/git24j/j_checkout.c
@@ -23,7 +23,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Checkout_jniOptionsNew)(JNIEnv *env, jclass
 {
     git_checkout_options *opts = (git_checkout_options *)malloc(sizeof(git_checkout_options));
     int r = git_checkout_init_options(opts, version);
-    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 

--- a/src/main/c/git24j/j_cherrypick.c
+++ b/src/main/c/git24j/j_cherrypick.c
@@ -18,7 +18,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Cherrypick_jniOptionsNew)(JNIEnv *env, jcla
 {
     git_cherrypick_options *opts = (git_cherrypick_options *)malloc(sizeof(git_cherrypick_options));
     int r = git_cherrypick_options_init(opts, version);
-    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 
@@ -52,7 +52,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Cherrypick_jniCommit)(JNIEnv *env, jclass o
 {
     git_index *c_out;
     int r = git_cherrypick_commit(&c_out, (git_repository *)repoPtr, (git_commit *)cherrypickCommitPtr, (git_commit *)ourCommitPtr, mainline, (git_merge_options *)mergeOptionsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_index_free(c_out); */
     return r;
 }

--- a/src/main/c/git24j/j_cherrypick.c
+++ b/src/main/c/git24j/j_cherrypick.c
@@ -28,6 +28,11 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Cherrypick_jniOptionsGetMainline)(JNIEnv *e
     return ((git_cherrypick_options *)optionsPtr)->mainline;
 }
 
+JNIEXPORT void JNICALL J_MAKE_METHOD(Cherrypick_jniOptionsSetMainline)(JNIEnv *env, jclass obj, jlong optionsPtr, jint mainline)
+{
+    ((git_cherrypick_options *)optionsPtr)->mainline = (unsigned int)mainline;
+}
+
 /** git_merge_options merge_opts*/
 JNIEXPORT jlong JNICALL J_MAKE_METHOD(Cherrypick_jniOptionsGetMergeOpts)(JNIEnv *env, jclass obj, jlong optionsPtr)
 {

--- a/src/main/c/git24j/j_cherrypick.h
+++ b/src/main/c/git24j/j_cherrypick.h
@@ -16,7 +16,7 @@ extern "C"
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Cherrypick_jniOptionsInit)(JNIEnv *env, jclass obj, jlong optsPtr, jint version);
     /** unsigned int mainline*/
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Cherrypick_jniOptionsGetMainline)(JNIEnv *env, jclass obj, jlong optionsPtr);
-    JNIEXPORT void JNICALL J_MAKE_METHOD(Cherrypick_jniOptionsSetMainline)(JNIEnv *env, jclass obj, jlong optionsPtr, jint mainline)
+    JNIEXPORT void JNICALL J_MAKE_METHOD(Cherrypick_jniOptionsSetMainline)(JNIEnv *env, jclass obj, jlong optionsPtr, jint mainline);
 
     /** git_merge_options merge_opts*/
     JNIEXPORT jlong JNICALL J_MAKE_METHOD(Cherrypick_jniOptionsGetMergeOpts)(JNIEnv *env, jclass obj, jlong optionsPtr);

--- a/src/main/c/git24j/j_cherrypick.h
+++ b/src/main/c/git24j/j_cherrypick.h
@@ -16,6 +16,8 @@ extern "C"
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Cherrypick_jniOptionsInit)(JNIEnv *env, jclass obj, jlong optsPtr, jint version);
     /** unsigned int mainline*/
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Cherrypick_jniOptionsGetMainline)(JNIEnv *env, jclass obj, jlong optionsPtr);
+    JNIEXPORT void JNICALL J_MAKE_METHOD(Cherrypick_jniOptionsSetMainline)(JNIEnv *env, jclass obj, jlong optionsPtr, jint mainline)
+
     /** git_merge_options merge_opts*/
     JNIEXPORT jlong JNICALL J_MAKE_METHOD(Cherrypick_jniOptionsGetMergeOpts)(JNIEnv *env, jclass obj, jlong optionsPtr);
     /** git_checkout_options checkout_opts*/

--- a/src/main/c/git24j/j_clone.c
+++ b/src/main/c/git24j/j_clone.c
@@ -17,7 +17,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Clone_jniClone)(JNIEnv *env, jclass obj, jo
     char *c_local_path = j_copy_of_jstring(env, local_path, true);
     git_clone_options *opts = (git_clone_options *)optionsPtr;
     int r = git_clone(&c_out, c_url, c_local_path, opts);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_url);
     free(c_local_path);
     return r;
@@ -33,7 +33,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Clone_jniOptionsNew)(JNIEnv *env, jclass ob
 {
     git_clone_options *opts = (git_clone_options *)malloc(sizeof(git_clone_options));
     int r = git_clone_init_options(opts, (unsigned int)version);
-    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 

--- a/src/main/c/git24j/j_commit.c
+++ b/src/main/c/git24j/j_commit.c
@@ -80,7 +80,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Commit_jniCommitterWithMailmap)(JNIEnv *env
 {
     git_signature *c_out = 0;
     int r = git_commit_committer_with_mailmap(&c_out, (git_commit *)commitPtr, (git_mailmap *)mailmapPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -89,7 +89,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Commit_jniAuthorWithMailmap)(JNIEnv *env, j
 {
     git_signature *c_out = 0;
     int r = git_commit_author_with_mailmap(&c_out, (git_commit *)commitPtr, (git_mailmap *)mailmapPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -105,7 +105,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Commit_jniTree)(JNIEnv *env, jclass obj, jo
 {
     git_tree *tree = 0;
     int e = git_commit_tree(&tree, (git_commit *)commitPtr);
-    (*env)->CallVoidMethod(env, outTreePtr, jniConstants->midAtomicLongSet, (long)tree);
+    (*env)->CallVoidMethod(env, outTreePtr, jniConstants->midAtomicLongSet, (jlong)tree);
     return e;
 }
 
@@ -117,17 +117,17 @@ JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Commit_jniTreeId)(JNIEnv *env, jclass
 }
 
 /**unsigned int git_commit_parentcount(const git_commit *commit); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Commit_jniParentCount)(JNIEnv *env, jclass obj, long commitPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Commit_jniParentCount)(JNIEnv *env, jclass obj, jlong commitPtr)
 {
     return (jint)git_commit_parentcount((git_commit *)commitPtr);
 }
 
 /**int git_commit_parent(git_commit **out, const git_commit *commit, unsigned int n); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Commit_jniParent)(JNIEnv *env, jclass obj, jobject outPtr, long commitPtr, jint n)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Commit_jniParent)(JNIEnv *env, jclass obj, jobject outPtr, jlong commitPtr, jint n)
 {
     git_commit *c_out = 0;
     int e = git_commit_parent(&c_out, (git_commit *)commitPtr, (unsigned int)n);
-    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)c_out);
     return e;
 }
 
@@ -143,7 +143,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Commit_jniNthGenAncestor)(JNIEnv *env, jcla
 {
     git_commit *ancestor = 0;
     int e = git_commit_nth_gen_ancestor(&ancestor, (git_commit *)commitPtr, (unsigned int)n);
-    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (long)ancestor);
+    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)ancestor);
     return e;
 }
 

--- a/src/main/c/git24j/j_commit.h
+++ b/src/main/c/git24j/j_commit.h
@@ -57,10 +57,10 @@ extern "C"
     JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Commit_jniTreeId)(JNIEnv *env, jclass obj, jlong commitPtr);
 
     /**unsigned int git_commit_parentcount(const git_commit *commit); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Commit_jniParentCount)(JNIEnv *env, jclass obj, long commitPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Commit_jniParentCount)(JNIEnv *env, jclass obj, jlong commitPtr);
 
     /**int git_commit_parent(git_commit **out, const git_commit *commit, unsigned int n); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Commit_jniParent)(JNIEnv *env, jclass obj, jobject outPtr, long commitPtr, jint n);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Commit_jniParent)(JNIEnv *env, jclass obj, jobject outPtr, jlong commitPtr, jint n);
 
     /**const git_oid * git_commit_parent_id(const git_commit *commit, unsigned int n); */
     JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Commit_jniParentId)(JNIEnv *env, jclass obj, jlong commitPtr, jint n);
@@ -75,10 +75,10 @@ extern "C"
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Commit_jniExtractSignature)(JNIEnv *env, jclass obj, jobject outBuf, jlong repoPtr, jobject commitId, jstring field);
 
     /**
-     * int git_commit_create(git_oid *id, 
-     *                       git_repository *repo, 
-     *                       const char *update_ref, 
-     *                       const git_signature *author, 
+     * int git_commit_create(git_oid *id,
+     *                       git_repository *repo,
+     *                       const char *update_ref,
+     *                       const git_signature *author,
      *                       const git_signature *committer,
      *                       const char *message_encoding,
      *                       const char *message,
@@ -97,23 +97,23 @@ extern "C"
                                                            jstring message,
                                                            jlong treePtr,
                                                            jlongArray parents);
-    /**int git_commit_create_v(git_oid *id, 
-     *                         git_repository *repo, 
-     *                         const char *update_ref, 
-     *                         const git_signature *author, 
-     *                         const git_signature *committer, 
-     *                         const char *message_encoding, 
-     *                         const char *message, 
-     *                         const git_tree *tree, 
+    /**int git_commit_create_v(git_oid *id,
+     *                         git_repository *repo,
+     *                         const char *update_ref,
+     *                         const git_signature *author,
+     *                         const git_signature *committer,
+     *                         const char *message_encoding,
+     *                         const char *message,
+     *                         const git_tree *tree,
      *                         size_t parent_count, ...); */
 
-    /**int git_commit_amend(git_oid *id, 
-     *                      const git_commit *commit_to_amend, 
-     *                      const char *update_ref, 
-     *                      const git_signature *author, 
-     *                      const git_signature *committer, 
-     *                      const char *message_encoding, 
-     *                      const char *message, 
+    /**int git_commit_amend(git_oid *id,
+     *                      const git_commit *commit_to_amend,
+     *                      const char *update_ref,
+     *                      const git_signature *author,
+     *                      const git_signature *committer,
+     *                      const char *message_encoding,
+     *                      const char *message,
      *                      const git_tree *tree); */
 
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Commit_jniAmend)(JNIEnv *env, jclass obj,
@@ -146,7 +146,7 @@ extern "C"
                                                                  jint parentCount,
                                                                  jlongArray parents);
 
-    /**int git_commit_create_with_signature(git_oid *out, 
+    /**int git_commit_create_with_signature(git_oid *out,
      *                                      git_repository *repo,
      *                                      const char *commit_content,
      *                                      const char *signature,

--- a/src/main/c/git24j/j_config.c
+++ b/src/main/c/git24j/j_config.c
@@ -42,6 +42,19 @@ JNIEXPORT jstring JNICALL J_MAKE_METHOD(Config_jniEntryGetValue)(JNIEnv *env, jc
     return (*env)->NewStringUTF(env, ((git_config_entry *)entryPtr)->value);
 }
 
+/** const char *backend_type */
+JNIEXPORT jstring JNICALL J_MAKE_METHOD(Config_jniEntryGetBackendType)(JNIEnv *env, jclass obj, jlong entryPtr)
+{
+    const char* c_char = ((git_config_entry *)entryPtr)->backend_type
+    return (*env)->NewStringUTF(env, c_char?c_char:"");
+}
+/** const char *origin_path */
+JNIEXPORT jstring JNICALL J_MAKE_METHOD(Config_jniEntryGetOriginPath)(JNIEnv *env, jclass obj, jlong entryPtr)
+{
+    const char* c_char = ((git_config_entry *)entryPtr)->origin_path
+    return (*env)->NewStringUTF(env, c_char?c_char:"");
+}
+
 /** unsigned int include_depth*/
 JNIEXPORT jint JNICALL J_MAKE_METHOD(Config_jniEntryGetIncludeDepth)(JNIEnv *env, jclass obj, jlong entryPtr)
 {

--- a/src/main/c/git24j/j_config.c
+++ b/src/main/c/git24j/j_config.c
@@ -45,13 +45,13 @@ JNIEXPORT jstring JNICALL J_MAKE_METHOD(Config_jniEntryGetValue)(JNIEnv *env, jc
 /** const char *backend_type */
 JNIEXPORT jstring JNICALL J_MAKE_METHOD(Config_jniEntryGetBackendType)(JNIEnv *env, jclass obj, jlong entryPtr)
 {
-    const char* c_char = ((git_config_entry *)entryPtr)->backend_type
+    const char* c_char = ((git_config_entry *)entryPtr)->backend_type;
     return (*env)->NewStringUTF(env, c_char?c_char:"");
 }
 /** const char *origin_path */
 JNIEXPORT jstring JNICALL J_MAKE_METHOD(Config_jniEntryGetOriginPath)(JNIEnv *env, jclass obj, jlong entryPtr)
 {
-    const char* c_char = ((git_config_entry *)entryPtr)->origin_path
+    const char* c_char = ((git_config_entry *)entryPtr)->origin_path;
     return (*env)->NewStringUTF(env, c_char?c_char:"");
 }
 

--- a/src/main/c/git24j/j_config.c
+++ b/src/main/c/git24j/j_config.c
@@ -105,7 +105,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Config_jniOpenDefault)(JNIEnv *env, jclass 
 {
     git_config *c_out = 0;
     int r = git_config_open_default(&c_out);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -114,7 +114,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Config_jniNew)(JNIEnv *env, jclass obj, job
 {
     git_config *c_out = 0;
     int r = git_config_new(&c_out);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -133,7 +133,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Config_jniOpenOndisk)(JNIEnv *env, jclass o
     git_config *c_out = 0;
     char *c_path = j_copy_of_jstring(env, path, true);
     int r = git_config_open_ondisk(&c_out, c_path);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_path);
     return r;
 }
@@ -143,7 +143,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Config_jniOpenLevel)(JNIEnv *env, jclass ob
 {
     git_config *c_out = 0;
     int r = git_config_open_level(&c_out, (git_config *)parentPtr, (git_config_level_t)level);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -152,7 +152,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Config_jniOpenGlobal)(JNIEnv *env, jclass o
 {
     git_config *c_out = 0;
     int r = git_config_open_global(&c_out, (git_config *)configPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -161,7 +161,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Config_jniSnapshot)(JNIEnv *env, jclass obj
 {
     git_config *c_out = 0;
     int r = git_config_snapshot(&c_out, (git_config *)configPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -177,7 +177,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Config_jniGetEntry)(JNIEnv *env, jclass obj
     git_config_entry *c_out = 0;
     char *c_name = j_copy_of_jstring(env, name, true);
     int r = git_config_get_entry(&c_out, (git_config *)cfgPtr, c_name);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_name);
     return r;
 }
@@ -274,7 +274,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Config_jniMultivarIteratorNew)(JNIEnv *env,
     char *c_name = j_copy_of_jstring(env, name, true);
     char *c_regexp = j_copy_of_jstring(env, regexp, true);
     int r = git_config_multivar_iterator_new(&c_out, (git_config *)cfgPtr, c_name, c_regexp);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_name);
     free(c_regexp);
     return r;
@@ -285,7 +285,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Config_jniNext)(JNIEnv *env, jclass obj, jo
 {
     git_config_entry *c_entry = 0;
     int r = git_config_next(&c_entry, (git_config_iterator *)iterPtr);
-    (*env)->CallVoidMethod(env, entry, jniConstants->midAtomicLongSet, (long)c_entry);
+    (*env)->CallVoidMethod(env, entry, jniConstants->midAtomicLongSet, (jlong)c_entry);
     return r;
 }
 
@@ -382,7 +382,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Config_jniIteratorNew)(JNIEnv *env, jclass 
 {
     git_config_iterator *c_out = 0;
     int r = git_config_iterator_new(&c_out, (git_config *)cfgPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -392,7 +392,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Config_jniIteratorGlobNew)(JNIEnv *env, jcl
     git_config_iterator *c_out = 0;
     char *c_regexp = j_copy_of_jstring(env, regexp, true);
     int r = git_config_iterator_glob_new(&c_out, (git_config *)cfgPtr, c_regexp);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_regexp);
     return r;
 }
@@ -473,6 +473,6 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Config_jniLock)(JNIEnv *env, jclass obj, jo
 {
     git_transaction *c_tx = 0;
     int r = git_config_lock(&c_tx, (git_config *)cfgPtr);
-    (*env)->CallVoidMethod(env, tx, jniConstants->midAtomicLongSet, (long)c_tx);
+    (*env)->CallVoidMethod(env, tx, jniConstants->midAtomicLongSet, (jlong)c_tx);
     return r;
 }

--- a/src/main/c/git24j/j_config.h
+++ b/src/main/c/git24j/j_config.h
@@ -13,6 +13,10 @@ extern "C"
     JNIEXPORT jstring JNICALL J_MAKE_METHOD(Config_jniEntryGetName)(JNIEnv *env, jclass obj, jlong entryPtr);
     /** const char *value*/
     JNIEXPORT jstring JNICALL J_MAKE_METHOD(Config_jniEntryGetValue)(JNIEnv *env, jclass obj, jlong entryPtr);
+    /** const char *value*/
+    JNIEXPORT jstring JNICALL J_MAKE_METHOD(Config_jniEntryGetBackendType)(JNIEnv *env, jclass obj, jlong entryPtr);
+    /** const char *value*/
+    JNIEXPORT jstring JNICALL J_MAKE_METHOD(Config_jniEntryGetOriginPath)(JNIEnv *env, jclass obj, jlong entryPtr);
     /** unsigned int include_depth*/
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Config_jniEntryGetIncludeDepth)(JNIEnv *env, jclass obj, jlong entryPtr);
     /** git_config_level_t level*/

--- a/src/main/c/git24j/j_cred.c
+++ b/src/main/c/git24j/j_cred.c
@@ -41,7 +41,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Cred_jniUserpassPlaintextNew)(JNIEnv *env, 
     char *c_username = j_copy_of_jstring(env, username, true);
     char *c_password = j_copy_of_jstring(env, password, true);
     int r = git_cred_userpass_plaintext_new(&c_out, c_username, c_password);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_username);
     free(c_password);
     return r;
@@ -56,7 +56,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Cred_jniSshKeyNew)(JNIEnv *env, jclass obj,
     char *c_privatekey = j_copy_of_jstring(env, privatekey, true);
     char *c_passphrase = j_copy_of_jstring(env, passphrase, true);
     int r = git_cred_ssh_key_new(&c_out, c_username, c_publickey, c_privatekey, c_passphrase);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_username);
     free(c_publickey);
     free(c_privatekey);
@@ -70,7 +70,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Cred_jniSshKeyFromAgent)(JNIEnv *env, jclas
     git_cred *c_out = 0;
     char *c_username = j_copy_of_jstring(env, username, true);
     int r = git_cred_ssh_key_from_agent(&c_out, c_username);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_username);
     return r;
 }
@@ -80,7 +80,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Cred_jniDefaultNew)(JNIEnv *env, jclass obj
 {
     git_cred *c_out = 0;
     int r = git_cred_default_new(&c_out);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -90,7 +90,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Cred_jniUsernameNew)(JNIEnv *env, jclass ob
     git_cred *c_cred = 0;
     char *c_username = j_copy_of_jstring(env, username, true);
     int r = git_cred_username_new(&c_cred, c_username);
-    (*env)->CallVoidMethod(env, cred, jniConstants->midAtomicLongSet, (long)c_cred);
+    (*env)->CallVoidMethod(env, cred, jniConstants->midAtomicLongSet, (jlong)c_cred);
     free(c_username);
     return r;
 }
@@ -104,7 +104,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Cred_jniSshKeyMemoryNew)(JNIEnv *env, jclas
     char *c_privatekey = j_copy_of_jstring(env, privatekey, true);
     char *c_passphrase = j_copy_of_jstring(env, passphrase, true);
     int r = git_cred_ssh_key_memory_new(&c_out, c_username, c_publickey, c_privatekey, c_passphrase);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_username);
     free(c_publickey);
     free(c_privatekey);

--- a/src/main/c/git24j/j_credential.c
+++ b/src/main/c/git24j/j_credential.c
@@ -66,7 +66,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Credential_jniUserpassPlaintextNew)(JNIEnv 
     char *c_username = j_copy_of_jstring(env, username, true);
     char *c_password = j_copy_of_jstring(env, password, true);
     int r = git_credential_userpass_plaintext_new(&c_out, c_username, c_password);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_credential_free(c_out); */
     free(c_username);
     free(c_password);
@@ -78,7 +78,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Credential_jniDefaultNew)(JNIEnv *env, jcla
 {
     git_credential *c_out = 0;
     int r = git_credential_default_new(&c_out);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_credential_free(c_out); */
     return r;
 }
@@ -89,7 +89,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Credential_jniUsernameNew)(JNIEnv *env, jcl
     git_credential *c_out = 0;
     char *c_username = j_copy_of_jstring(env, username, true);
     int r = git_credential_username_new(&c_out, c_username);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_credential_free(c_out); */
     free(c_username);
     return r;
@@ -104,7 +104,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Credential_jniSshKeyNew)(JNIEnv *env, jclas
     char *c_privatekey = j_copy_of_jstring(env, privatekey, true);
     char *c_passphrase = j_copy_of_jstring(env, passphrase, true);
     int r = git_credential_ssh_key_new(&c_out, c_username, c_publickey, c_privatekey, c_passphrase);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_credential_free(c_out); */
     free(c_username);
     free(c_publickey);
@@ -122,7 +122,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Credential_jniSshKeyMemoryNew)(JNIEnv *env,
     char *c_privatekey = j_copy_of_jstring(env, privatekey, true);
     char *c_passphrase = j_copy_of_jstring(env, passphrase, true);
     int r = git_credential_ssh_key_memory_new(&c_out, c_username, c_publickey, c_privatekey, c_passphrase);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_credential_free(c_out); */
     free(c_username);
     free(c_publickey);
@@ -137,7 +137,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Credential_jniSshKeyFromAgent)(JNIEnv *env,
     git_credential *c_out = 0;
     char *c_username = j_copy_of_jstring(env, username, true);
     int r = git_credential_ssh_key_from_agent(&c_out, c_username);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_credential_free(c_out); */
     free(c_username);
     return r;
@@ -150,7 +150,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Credential_jniUserpass)(JNIEnv *env, jclass
     char *c_url = j_copy_of_jstring(env, url, true);
     char *c_user_from_url = j_copy_of_jstring(env, user_from_url, true);
     int r = git_credential_userpass(&c_out, c_url, c_user_from_url, allowedTypes, (void *)payload);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_credential_free(c_out); */
     free(c_url);
     free(c_user_from_url);

--- a/src/main/c/git24j/j_describe.c
+++ b/src/main/c/git24j/j_describe.c
@@ -14,7 +14,7 @@ JNIEXPORT int JNICALL J_MAKE_METHOD(Describe_jniOptionsNew)(JNIEnv *env, jclass 
     git_describe_options *opts = (git_describe_options *)malloc(sizeof(git_describe_options));
     opts->pattern = NULL;
     int r = git_describe_options_init(opts, (unsigned int)version);
-    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 
@@ -99,7 +99,7 @@ JNIEXPORT int JNICALL J_MAKE_METHOD(Describe_jniFormatOptionsNew)(JNIEnv *env, j
     git_describe_format_options *opts = (git_describe_format_options *)malloc(sizeof(git_describe_format_options));
     opts->dirty_suffix = NULL;
     int r = git_describe_format_options_init(opts, version);
-    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 
@@ -175,7 +175,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Describe_jniWorkdir)(JNIEnv *env, jclass ob
 {
     git_describe_result *c_out;
     int r = git_describe_workdir(&c_out, (git_repository *)repoPtr, (git_describe_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_describe_result_free(c_out); */
     return r;
 }

--- a/src/main/c/git24j/j_diff.c
+++ b/src/main/c/git24j/j_diff.c
@@ -497,7 +497,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniCommitAsEmail)(JNIEnv *env, jclass 
     return r;
 }
 /** new and init git_diff_format_email_options */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniFormatEmailNewOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jobject outPtr, jint version)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniFormatEmailNewOptions)(JNIEnv *env, jclass obj, jobject outPtr, jint version)
 {
     git_diff_format_email_options *out = (git_diff_format_email_options *)malloc(sizeof(git_diff_format_email_options));
     int r = git_diff_format_email_init_options(out, version);

--- a/src/main/c/git24j/j_diff.c
+++ b/src/main/c/git24j/j_diff.c
@@ -702,6 +702,14 @@ JNIEXPORT jstring JNICALL J_MAKE_METHOD(Diff_jniLineGetContent)(JNIEnv *env, jcl
     return (*env)->NewStringUTF(env, ((git_diff_line *)linePtr)->content);
 }
 
+JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Diff_jniLineGetContentBytes)(JNIEnv *env, jclass obj, jlong linePtr)
+{
+    git_diff_line* dline = (git_diff_line *) linePtr;
+    size_t len = dline->content_len;
+
+    return j_byte_array_from_c(env, dline->content, len);
+}
+
 /** -------- Wrapper Body ---------- */
 /** unsigned int contains_data*/
 JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniBinaryGetContainsData)(JNIEnv *env, jclass obj, jlong binaryPtr)

--- a/src/main/c/git24j/j_diff.c
+++ b/src/main/c/git24j/j_diff.c
@@ -650,13 +650,26 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniHunkGetNewLines)(JNIEnv *env, jclas
 /** size_t header_len*/
 JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniHunkGetHeaderLen)(JNIEnv *env, jclass obj, jlong hunkPtr)
 {
+    // The libgit2 doc haven't wrote, but this length should not include terminated NUL-byte('\0') of `hunk->header`
     return ((git_diff_hunk *)hunkPtr)->header_len;
 }
 
 /** const char*   header*/
 JNIEXPORT jstring JNICALL J_MAKE_METHOD(Diff_jniHunkGetHeader)(JNIEnv *env, jclass obj, jlong hunkPtr)
 {
+    // due to hunk->header terminated by '\0' (libgit2 doc said),
+    // this should ever get header with right length(the String bytes length should equals to `hunk->header_len`)
     return (*env)->NewStringUTF(env, ((git_diff_hunk *)hunkPtr)->header);
+}
+
+JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Diff_jniHunkGetHeaderBytes)(JNIEnv *env, jclass obj, jlong hunkPtr)
+{
+    git_diff_hunk* hunk = (git_diff_hunk *) hunkPtr;
+    //https://libgit2.org/libgit2/#v1.7.2/type/git_diff_hunk
+    //I guess this header_len is not include '\0', but the libgit2 doc omit the info
+    size_t len = hunk->header_len;
+
+    return j_byte_array_from_c(env, hunk->header, len);
 }
 
 /************ diff line *************/

--- a/src/main/c/git24j/j_diff.c
+++ b/src/main/c/git24j/j_diff.c
@@ -122,7 +122,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniInitOptions)(JNIEnv *env, jclass ob
 {
     git_diff_options *opts = (git_diff_options *)malloc(sizeof(git_diff_options));
     int r = git_diff_init_options(opts, version);
-    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 
@@ -137,7 +137,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniFindInitOptions)(JNIEnv *env, jclas
 {
     git_diff_find_options *opts = (git_diff_find_options *)malloc(sizeof(git_diff_find_options));
     int r = git_diff_find_init_options(opts, version);
-    (*env)->CallVoidMethod(env, outFindOpts, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outFindOpts, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 
@@ -157,7 +157,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniTreeToTree)(JNIEnv *env, jclass obj
 {
     git_diff *c_diff = 0;
     int r = git_diff_tree_to_tree(&c_diff, (git_repository *)repoPtr, (git_tree *)oldTreePtr, (git_tree *)newTreePtr, (git_diff_options *)optsPtr);
-    (*env)->CallVoidMethod(env, diff, jniConstants->midAtomicLongSet, (long)c_diff);
+    (*env)->CallVoidMethod(env, diff, jniConstants->midAtomicLongSet, (jlong)c_diff);
     return r;
 }
 
@@ -166,7 +166,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniTreeToIndex)(JNIEnv *env, jclass ob
 {
     git_diff *c_diff = 0;
     int r = git_diff_tree_to_index(&c_diff, (git_repository *)repoPtr, (git_tree *)oldTreePtr, (git_index *)indexPtr, (git_diff_options *)optsPtr);
-    (*env)->CallVoidMethod(env, diff, jniConstants->midAtomicLongSet, (long)c_diff);
+    (*env)->CallVoidMethod(env, diff, jniConstants->midAtomicLongSet, (jlong)c_diff);
     return r;
 }
 
@@ -175,7 +175,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniIndexToWorkdir)(JNIEnv *env, jclass
 {
     git_diff *c_diff = 0;
     int r = git_diff_index_to_workdir(&c_diff, (git_repository *)repoPtr, (git_index *)indexPtr, (git_diff_options *)optsPtr);
-    (*env)->CallVoidMethod(env, diff, jniConstants->midAtomicLongSet, (long)c_diff);
+    (*env)->CallVoidMethod(env, diff, jniConstants->midAtomicLongSet, (jlong)c_diff);
     return r;
 }
 
@@ -184,7 +184,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniTreeToWorkdir)(JNIEnv *env, jclass 
 {
     git_diff *c_diff = 0;
     int r = git_diff_tree_to_workdir(&c_diff, (git_repository *)repoPtr, (git_tree *)oldTreePtr, (git_diff_options *)optsPtr);
-    (*env)->CallVoidMethod(env, diff, jniConstants->midAtomicLongSet, (long)c_diff);
+    (*env)->CallVoidMethod(env, diff, jniConstants->midAtomicLongSet, (jlong)c_diff);
     return r;
 }
 
@@ -193,7 +193,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniTreeToWorkdirWithIndex)(JNIEnv *env
 {
     git_diff *c_diff = 0;
     int r = git_diff_tree_to_workdir_with_index(&c_diff, (git_repository *)repoPtr, (git_tree *)oldTreePtr, (git_diff_options *)optsPtr);
-    (*env)->CallVoidMethod(env, diff, jniConstants->midAtomicLongSet, (long)c_diff);
+    (*env)->CallVoidMethod(env, diff, jniConstants->midAtomicLongSet, (jlong)c_diff);
     return r;
 }
 
@@ -202,7 +202,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniIndexToIndex)(JNIEnv *env, jclass o
 {
     git_diff *c_diff = 0;
     int r = git_diff_index_to_index(&c_diff, (git_repository *)repoPtr, (git_index *)oldIndexPtr, (git_index *)newIndexPtr, (git_diff_options *)optsPtr);
-    (*env)->CallVoidMethod(env, diff, jniConstants->midAtomicLongSet, (long)c_diff);
+    (*env)->CallVoidMethod(env, diff, jniConstants->midAtomicLongSet, (jlong)c_diff);
     return r;
 }
 
@@ -425,7 +425,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniFromBuffer)(JNIEnv *env, jclass obj
     git_diff *c_out = 0;
     char *c_content = j_copy_of_jstring(env, content, true);
     int r = git_diff_from_buffer(&c_out, c_content, contentLen);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_content);
     return r;
 }
@@ -435,7 +435,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniGetStats)(JNIEnv *env, jclass obj, 
 {
     git_diff_stats *c_out = 0;
     int r = git_diff_get_stats(&c_out, (git_diff *)diffPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     git_diff_stats_free(c_out);
     return r;
 }
@@ -501,7 +501,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniFormatEmailNewOptions)(JNIEnv *env,
 {
     git_diff_format_email_options *out = (git_diff_format_email_options *)malloc(sizeof(git_diff_format_email_options));
     int r = git_diff_format_email_init_options(out, version);
-    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (long)out);
+    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)out);
     return r;
 }
 
@@ -531,7 +531,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniPatchidOptionsNew)(JNIEnv *env, jcl
     git_diff_patchid_options *opts = (git_diff_patchid_options *)malloc(sizeof(git_diff_patchid_options));
     int r = git_diff_patchid_options_init(opts, version);
     // int r = git_diff_patchid_init_options(opts, version);
-    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 /** free git_diff_patchid_options */

--- a/src/main/c/git24j/j_diff.h
+++ b/src/main/c/git24j/j_diff.h
@@ -124,7 +124,7 @@ extern "C"
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniFormatEmailInitOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jint version);
 
     /** new and init git_diff_format_email_options */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniFormatEmailNewOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jobject outPtr, jint version);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniFormatEmailNewOptions)(JNIEnv *env, jclass obj, jobject outPtr, jint version);
 
     /** free git_diff_format_email_options *opts. */
     JNIEXPORT void JNICALL J_MAKE_METHOD(Diff_jniFormatEmailOptionsFree)(JNIEnv *env, jclass obj, jlong optsPtr);

--- a/src/main/c/git24j/j_diff.h
+++ b/src/main/c/git24j/j_diff.h
@@ -195,6 +195,7 @@ extern "C"
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniLineGetContentOffset)(JNIEnv *env, jclass obj, jlong linePtr);
     /** const char *content*/
     JNIEXPORT jstring JNICALL J_MAKE_METHOD(Diff_jniLineGetContent)(JNIEnv *env, jclass obj, jlong linePtr);
+    JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Diff_jniLineGetContentBytes)(JNIEnv *env, jclass obj, jlong linePtr);
 
     /************ diff binary *************/
     /** unsigned int contains_data*/

--- a/src/main/c/git24j/j_diff.h
+++ b/src/main/c/git24j/j_diff.h
@@ -179,7 +179,7 @@ extern "C"
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Diff_jniHunkGetHeaderLen)(JNIEnv *env, jclass obj, jlong hunkPtr);
     /** const char*   header*/
     JNIEXPORT jstring JNICALL J_MAKE_METHOD(Diff_jniHunkGetHeader)(JNIEnv *env, jclass obj, jlong hunkPtr);
-
+    JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Diff_jniHunkGetHeaderBytes)(JNIEnv *env, jclass obj, jlong hunkPtr);
     /************ diff line *************/
     /** char   origin*/
     JNIEXPORT jchar JNICALL J_MAKE_METHOD(Diff_jniLineGetOrigin)(JNIEnv *env, jclass obj, jlong linePtr);

--- a/src/main/c/git24j/j_errors.c
+++ b/src/main/c/git24j/j_errors.c
@@ -3,7 +3,7 @@
 #include <assert.h>
 #include <git2.h>
 
-JNIEXPORT jobject JNICALL J_MAKE_METHOD(Error_jniLast)(JNIEnv *env, jclass obj)
+JNIEXPORT jthrowable JNICALL J_MAKE_METHOD(Error_jniLast)(JNIEnv *env, jclass obj)
 {
     const git_error *error = git_error_last();
     if (error == NULL)

--- a/src/main/c/git24j/j_errors.c
+++ b/src/main/c/git24j/j_errors.c
@@ -23,17 +23,21 @@ JNIEXPORT jobject JNICALL J_MAKE_METHOD(Error_jniLast)(JNIEnv *env, jclass obj)
 
 JNIEXPORT void JNICALL J_MAKE_METHOD(Error_jniClear)(JNIEnv *env, jclass obj)
 {
-    git_error_clear();
+    // deprecated by libgit2 1.8.x
+//    git_error_clear();
 }
 
 JNIEXPORT void JNICALL J_MAKE_METHOD(Error_jniSetStr)(JNIEnv *env, jclass obj, jint klass, jstring message)
 {
-    const char *c_msg = (*env)->GetStringUTFChars(env, message, NULL);
-    git_error_set_str((int)klass, c_msg);
-    (*env)->ReleaseStringUTFChars(env, message, c_msg);
+    // deprecated by libgit2 1.8.x
+//    const char *c_msg = (*env)->GetStringUTFChars(env, message, NULL);
+//    git_error_set_str((int)klass, c_msg);
+//    (*env)->ReleaseStringUTFChars(env, message, c_msg);
 }
 
 JNIEXPORT void JNICALL J_MAKE_METHOD(Error_jniSetOom)(JNIEnv *env, jclass obj)
 {
-    git_error_set_oom();
+    // deprecated by libgit2 1.8.x
+
+//    git_error_set_oom();
 }

--- a/src/main/c/git24j/j_errors.h
+++ b/src/main/c/git24j/j_errors.h
@@ -8,7 +8,7 @@ extern "C"
 {
 #endif
 
-    JNIEXPORT jobject JNICALL J_MAKE_METHOD(Error_jniLast)(JNIEnv *, jclass);
+    JNIEXPORT jthrowable JNICALL J_MAKE_METHOD(Error_jniLast)(JNIEnv *, jclass);
 
     JNIEXPORT void JNICALL J_MAKE_METHOD(Error_jniClear)(JNIEnv *, jclass);
 

--- a/src/main/c/git24j/j_filter_list.c
+++ b/src/main/c/git24j/j_filter_list.c
@@ -15,7 +15,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(FilterList_jniLoad)(JNIEnv *env, jclass obj
     git_filter_list *c_filters;
     char *c_path = j_copy_of_jstring(env, path, true);
     int r = git_filter_list_load(&c_filters, (git_repository *)repoPtr, (git_blob *)blobPtr, c_path, mode, flags);
-    (*env)->CallVoidMethod(env, filters, jniConstants->midAtomicLongSet, (long)c_filters);
+    (*env)->CallVoidMethod(env, filters, jniConstants->midAtomicLongSet, (jlong)c_filters);
     /* git_filter_list_free(c_filters); */
     free(c_path);
     return r;

--- a/src/main/c/git24j/j_gitobject.c
+++ b/src/main/c/git24j/j_gitobject.c
@@ -14,7 +14,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(GitObject_jniType)(JNIEnv *env, jclass obj,
     return git_object_type((git_object *)objPtr);
 }
 
-JNIEXPORT void JNICALL J_MAKE_METHOD(GitObject_jniId)(JNIEnv *env, jclass obj, jobject objPtr, jobject outId)
+JNIEXPORT void JNICALL J_MAKE_METHOD(GitObject_jniId)(JNIEnv *env, jclass obj, jlong objPtr, jobject outId)
 {
     const git_oid *c_oid = git_object_id((git_object *)objPtr);
     j_git_oid_to_java(env, c_oid, outId);
@@ -35,7 +35,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(GitObject_jniLookup)(JNIEnv *env, jclass ob
     git_oid c_oid;
     j_git_oid_from_java(env, oid, &c_oid);
     int error = git_object_lookup(&out_obj, (git_repository *)repoPtr, &c_oid, (git_object_t)objType);
-    (*env)->CallVoidMethod(env, outObj, jniConstants->midAtomicLongSet, (long)out_obj);
+    (*env)->CallVoidMethod(env, outObj, jniConstants->midAtomicLongSet, (jlong)out_obj);
     return error;
 }
 
@@ -51,7 +51,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(GitObject_jniLookupPrefix)(JNIEnv *env, jcl
     }
 
     int error = git_object_lookup_prefix(&out_obj, (git_repository *)repoPtr, &c_oid, (size_t)short_id_len, (git_object_t)objType);
-    (*env)->CallVoidMethod(env, outObj, jniConstants->midAtomicLongSet, (long)out_obj);
+    (*env)->CallVoidMethod(env, outObj, jniConstants->midAtomicLongSet, (jlong)out_obj);
     return error;
 }
 
@@ -64,7 +64,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(GitObject_jniPeel)(JNIEnv *env, jclass obj,
 {
     git_object *out_obj = 0;
     int error = git_object_peel(&out_obj, (git_object *)objPtr, (git_object_t)objType);
-    (*env)->CallVoidMethod(env, outObj, jniConstants->midAtomicLongSet, (long)out_obj);
+    (*env)->CallVoidMethod(env, outObj, jniConstants->midAtomicLongSet, (jlong)out_obj);
     return error;
 }
 
@@ -72,6 +72,6 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(GitObject_jniDup)(JNIEnv *env, jclass obj, 
 {
     git_object *out_obj = 0;
     int error = git_object_dup(&out_obj, (git_object *)objPtr);
-    (*env)->CallVoidMethod(env, outObj, jniConstants->midAtomicLongSet, (long)out_obj);
+    (*env)->CallVoidMethod(env, outObj, jniConstants->midAtomicLongSet, (jlong)out_obj);
     return error;
 }

--- a/src/main/c/git24j/j_gitobject.h
+++ b/src/main/c/git24j/j_gitobject.h
@@ -15,7 +15,7 @@ extern "C"
     JNIEXPORT jint JNICALL J_MAKE_METHOD(GitObject_jniType)(JNIEnv *env, jclass obj, jlong objPtr);
 
     /** const git_oid * git_object_id(const git_object *obj); */
-    JNIEXPORT void JNICALL J_MAKE_METHOD(GitObject_jniId)(JNIEnv *env, jclass obj, jobject objPtr, jobject outId);
+    JNIEXPORT void JNICALL J_MAKE_METHOD(GitObject_jniId)(JNIEnv *env, jclass obj, jlong objPtr, jobject outId);
 
     /**int git_object_short_id(git_buf *out, const git_object *obj); */
     JNIEXPORT jint JNICALL J_MAKE_METHOD(GitObject_jniShortId)(JNIEnv *env, jclass obj, jobject outBuf, jlong objPtr);

--- a/src/main/c/git24j/j_index.c
+++ b/src/main/c/git24j/j_index.c
@@ -53,7 +53,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Index_jniOpen)(JNIEnv *env, jclass obj, job
     git_index *c_out = 0;
     char *index_path = j_copy_of_jstring(env, indexPath, false);
     int e = git_index_open(&c_out, index_path);
-    (*env)->CallVoidMethod(env, outIndexPtr, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outIndexPtr, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(index_path);
     return e;
 }
@@ -94,7 +94,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Index_jniSetVersion)(JNIEnv *env, jclass ob
 }
 
 /** int git_index_read(git_index *index, int force); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Index_jniRead)(JNIEnv *env, jclass obj, jlong indexPtr, int force)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Index_jniRead)(JNIEnv *env, jclass obj, jlong indexPtr, jint force)
 {
     return git_index_read((git_index *)indexPtr, force);
 }
@@ -208,7 +208,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Index_jniIteratorNew)(JNIEnv *env, jclass o
 {
     git_index_iterator *iterator_out = 0;
     int e = git_index_iterator_new(&iterator_out, (git_index *)indexPtr);
-    (*env)->CallVoidMethod(env, outIterPtr, jniConstants->midAtomicLongSet, (long)iterator_out);
+    (*env)->CallVoidMethod(env, outIterPtr, jniConstants->midAtomicLongSet, (jlong)iterator_out);
     return e;
 }
 
@@ -217,7 +217,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Index_jniIteratorNext)(JNIEnv *env, jclass 
 {
     const git_index_entry *c_out = 0;
     int e = git_index_iterator_next(&c_out, (git_index_iterator *)iterPtr);
-    (*env)->CallVoidMethod(env, outEntryPtr, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outEntryPtr, jniConstants->midAtomicLongSet, (jlong)c_out);
     return e;
 }
 
@@ -348,7 +348,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Index_jniConflictIteratorNew)(JNIEnv *env, 
 {
     git_index_conflict_iterator *iterator_out = 0;
     int e = git_index_conflict_iterator_new(&iterator_out, (git_index *)indexPtr);
-    (*env)->CallVoidMethod(env, outIterPtr, jniConstants->midAtomicLongSet, (long)iterator_out);
+    (*env)->CallVoidMethod(env, outIterPtr, jniConstants->midAtomicLongSet, (jlong)iterator_out);
     return e;
 }
 
@@ -359,9 +359,9 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Index_jniConflictNext)(JNIEnv *env, jclass 
     const git_index_entry *our_out = 0;
     const git_index_entry *their_out = 0;
     int e = git_index_conflict_next(&ancestor_out, &our_out, &their_out, (git_index_conflict_iterator *)iterPtr);
-    (*env)->CallVoidMethod(env, ancestorOut, jniConstants->midAtomicLongSet, (long)ancestor_out);
-    (*env)->CallVoidMethod(env, ourOut, jniConstants->midAtomicLongSet, (long)our_out);
-    (*env)->CallVoidMethod(env, theirOut, jniConstants->midAtomicLongSet, (long)their_out);
+    (*env)->CallVoidMethod(env, ancestorOut, jniConstants->midAtomicLongSet, (jlong)ancestor_out);
+    (*env)->CallVoidMethod(env, ourOut, jniConstants->midAtomicLongSet, (jlong)our_out);
+    (*env)->CallVoidMethod(env, theirOut, jniConstants->midAtomicLongSet, (jlong)their_out);
     return e;
 }
 /** void git_index_conflict_iterator_free(git_index_conflict_iterator *iterator); */

--- a/src/main/c/git24j/j_index.h
+++ b/src/main/c/git24j/j_index.h
@@ -10,14 +10,14 @@ extern "C"
 {
 #endif
 
-    /** standard callback that forwards c-callback to java. 
+    /** standard callback that forwards c-callback to java.
      * c: standard_matched_cb(path, pathspec, ...)
      * java: class IndexMachedCallback extends BiConsumer<String, String> {
      *     @override
      *     public void accept(String path, String pathspec) {
      *     }
      * }
-     * 
+     *
      * jniAddAll(indexPtr.get(), new String[]{"foo/", "bar/"}, 0, (path, pathSpec) -> { ... })
      */
     int standard_matched_cb(const char *path, const char *matched_pathspec, void *payload);
@@ -41,7 +41,7 @@ extern "C"
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Index_jniSetVersion)(JNIEnv *env, jclass obj, jlong idxPtr, jint version);
 
     /** int git_index_read(git_index *index, int force); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Index_jniRead)(JNIEnv *env, jclass obj, jlong indexPtr, int force);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Index_jniRead)(JNIEnv *env, jclass obj, jlong indexPtr, jint force);
     /** int git_index_write(git_index *index); */
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Index_jniWrite)(JNIEnv *env, jclass obj, jlong index);
 

--- a/src/main/c/git24j/j_indexer.c
+++ b/src/main/c/git24j/j_indexer.c
@@ -21,7 +21,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Indexer_jniNew)(JNIEnv *env, jclass obj, jo
     git_indexer *c_out;
     char *c_path = j_copy_of_jstring(env, path, true);
     int r = git_indexer_new(&c_out, c_path, mode, (git_odb *)odbPtr, (git_indexer_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_indexer_free(c_out); */
     free(c_path);
     return r;
@@ -78,7 +78,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Indexer_jniOptionsNew)(JNIEnv *env, jclass 
     int r = git_indexer_options_init(opts, version);
     opts->progress_cb = j_git_indexer_progress_cb;
     opts->progress_cb_payload = (void *)payload;
-    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 

--- a/src/main/c/git24j/j_libgit2.c
+++ b/src/main/c/git24j/j_libgit2.c
@@ -144,7 +144,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Libgit2_features)(JNIEnv *env, jclass obj)
     return git_libgit2_features();
 }
 
-JNIEXPORT void JNICALL J_MAKE_METHOD(Libgit2_jniShadowFree)(JNIEnv *env, jclass obj, long ptr)
+JNIEXPORT void JNICALL J_MAKE_METHOD(Libgit2_jniShadowFree)(JNIEnv *env, jclass obj, jlong ptr)
 {
     free((void *)ptr);
 }

--- a/src/main/c/git24j/j_libgit2.h
+++ b/src/main/c/git24j/j_libgit2.h
@@ -21,7 +21,7 @@ extern "C"
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Libgit2_features)(JNIEnv *, jclass);
 
     /**call free(void* ptr) without recursively freeing fields. */
-    JNIEXPORT void JNICALL J_MAKE_METHOD(Libgit2_jniShadowFree)(JNIEnv *env, jclass obj, long ptr);
+    JNIEXPORT void JNICALL J_MAKE_METHOD(Libgit2_jniShadowFree)(JNIEnv *env, jclass obj, jlong ptr);
 
     // git_libgit2_opts() start
     //GIT_OPT_SET_MWINDOW_SIZE

--- a/src/main/c/git24j/j_mailmap.c
+++ b/src/main/c/git24j/j_mailmap.c
@@ -33,7 +33,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Mailmap_jniFromBuffer)(JNIEnv *env, jclass 
     size_t len = strlen(c_buf);
     git_mailmap *c_out = 0;
     int e = git_mailmap_from_buffer(&c_out, c_buf, len);
-    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_buf);
     return e;
 }
@@ -43,7 +43,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Mailmap_jniFromRepository)(JNIEnv *env, jcl
 {
     git_mailmap *c_out = 0;
     int e = git_mailmap_from_repository(&c_out, (git_repository *)repoPtr);
-    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)c_out);
     return e;
 }
 
@@ -75,6 +75,6 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Mailmap_jniResolveSignature)(JNIEnv *env, j
 {
     git_signature *c_out = 0;
     int r = git_mailmap_resolve_signature(&c_out, (git_mailmap *)mmPtr, (git_signature *)sigPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }

--- a/src/main/c/git24j/j_mappers.c
+++ b/src/main/c/git24j/j_mappers.c
@@ -369,6 +369,7 @@ void j_call_setter_string(JNIEnv *env, jclass clz, jobject obj, const char *meth
 
 void j_call_setter_string_c(JNIEnv *env, jclass clz, jobject obj, const char *method, const char *val)
 {
+    //NewStringUTF how know chars length when chars is c char* ? maybe it doesn't copy data? just make a pointer? idk
     jstring jVal = (*env)->NewStringUTF(env, val);
     j_call_setter_string(env, clz, obj, method, jVal);
     (*env)->DeleteLocalRef(env, jVal);

--- a/src/main/c/git24j/j_merge.c
+++ b/src/main/c/git24j/j_merge.c
@@ -25,7 +25,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Merge_jniFileInputNew)(JNIEnv *env, jclass 
 {
     git_merge_file_input *opts = (git_merge_file_input *)malloc(sizeof(git_merge_file_input));
     int r = git_merge_file_init_input(opts, version);
-    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 
@@ -118,7 +118,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Merge_jniFileOptionsNew)(JNIEnv *env, jclas
     opts->our_label = NULL;
     opts->their_label = NULL;
     int r = git_merge_file_init_options((git_merge_file_options *)opts, version);
-    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 
@@ -234,7 +234,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Merge_jniOptionsNew)(JNIEnv *env, jclass ob
     git_merge_options *opts = (git_merge_options *)malloc(sizeof(git_merge_options));
     opts->default_driver = NULL;
     int r = git_merge_init_options((git_merge_options *)opts, version);
-    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 JNIEXPORT void JNICALL J_MAKE_METHOD(Merge_jniOptionsFree)(JNIEnv *env, jclass obj, jlong opts)
@@ -389,7 +389,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Merge_jniTrees)(JNIEnv *env, jclass obj, jo
 {
     git_index *c_out = 0;
     int r = git_merge_trees(&c_out, (git_repository *)repoPtr, (git_tree *)ancestorTreePtr, (git_tree *)ourTreePtr, (git_tree *)theirTreePtr, (git_merge_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -398,7 +398,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Merge_jniCommits)(JNIEnv *env, jclass obj, 
 {
     git_index *c_out = 0;
     int r = git_merge_commits(&c_out, (git_repository *)repoPtr, (git_commit *)ourCommitPtr, (git_commit *)theirCommitPtr, (git_merge_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -508,7 +508,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Merge_jniFile)(JNIEnv *env, jclass obj, job
         (const git_merge_file_input *)oursPtr,
         (const git_merge_file_input *)theirsPtr,
         (const git_merge_file_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -530,7 +530,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Merge_jniFileFromIndex)(JNIEnv *env, jclass
         (const git_index_entry *)oursPtr,
         (const git_index_entry *)theirsPtr,
         (const git_merge_file_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 

--- a/src/main/c/git24j/j_message.c
+++ b/src/main/c/git24j/j_message.c
@@ -27,7 +27,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Message_jniTrailers)(JNIEnv *env, jclass ob
     char *c_message = j_copy_of_jstring(env, message, true);
     git_message_trailer_array *ptr = (git_message_trailer_array *)malloc(sizeof(git_message_trailer_array));
     int r = git_message_trailers(ptr, c_message);
-    (*env)->CallVoidMethod(env, outArrPtr, jniConstants->midAtomicLongSet, (long)ptr);
+    (*env)->CallVoidMethod(env, outArrPtr, jniConstants->midAtomicLongSet, (jlong)ptr);
     free(c_message);
     return r;
 }

--- a/src/main/c/git24j/j_note.c
+++ b/src/main/c/git24j/j_note.c
@@ -50,7 +50,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Note_jniIteratorNew)(JNIEnv *env, jclass ob
     git_note_iterator *c_out = 0;
     char *c_notes_ref = j_copy_of_jstring(env, notes_ref, true);
     int r = git_note_iterator_new(&c_out, (git_repository *)repoPtr, c_notes_ref);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_note_iterator_free(c_out); */
     free(c_notes_ref);
     return r;
@@ -61,7 +61,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Note_jniCommitIteratorNew)(JNIEnv *env, jcl
 {
     git_note_iterator *c_out = 0;
     int r = git_note_commit_iterator_new(&c_out, (git_commit *)notesCommitPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_note_iterator_free(c_out); */
     return r;
 }
@@ -91,7 +91,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Note_jniRead)(JNIEnv *env, jclass obj, jobj
     git_oid c_oid;
     j_git_oid_from_java(env, oid, &c_oid);
     int r = git_note_read(&c_out, (git_repository *)repoPtr, c_notes_ref, &c_oid);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_note_free(c_out); */
     free(c_notes_ref);
     return r;
@@ -104,7 +104,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Note_jniCommitRead)(JNIEnv *env, jclass obj
     git_oid c_oid;
     j_git_oid_from_java(env, oid, &c_oid);
     int r = git_note_commit_read(&c_out, (git_repository *)repoPtr, (git_commit *)notesCommitPtr, &c_oid);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_note_free(c_out); */
     return r;
 }

--- a/src/main/c/git24j/j_odb.c
+++ b/src/main/c/git24j/j_odb.c
@@ -28,7 +28,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Odb_jniNew)(JNIEnv *env, jclass obj, jobjec
 {
     git_odb *c_out = 0;
     int r = git_odb_new(&c_out);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_odb_free(c_out); */
     return r;
 }
@@ -39,7 +39,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Odb_jniOpen)(JNIEnv *env, jclass obj, jobje
     git_odb *c_out = 0;
     char *c_objects_dir = j_copy_of_jstring(env, objects_dir, true);
     int r = git_odb_open(&c_out, c_objects_dir);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_odb_free(c_out); */
     free(c_objects_dir);
     return r;
@@ -67,7 +67,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Odb_jniRead)(JNIEnv *env, jclass obj, jobje
     git_oid c_id;
     j_git_oid_from_java(env, id, &c_id);
     int r = git_odb_read(&c_out, (git_odb *)dbPtr, &c_id);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_odb_object_free(c_out); */
     return r;
 }
@@ -84,7 +84,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Odb_jniReadPrefix)(JNIEnv *env, jclass obj,
         return e;
     }
     int r = git_odb_read_prefix(&c_out, (git_odb *)dbPtr, &c_short_id, short_id_len);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -202,7 +202,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Odb_jniOpenWstream)(JNIEnv *env, jclass obj
 {
     git_odb_stream *c_out = 0;
     int r = git_odb_open_wstream(&c_out, (git_odb *)dbPtr, size, type);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_odb_stream_free(c_out); */
     return r;
 }
@@ -240,7 +240,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Odb_jniOpenRstream)(JNIEnv *env, jclass obj
     git_object_t c_type;
     j_git_oid_from_java(env, oid, &c_oid);
     int r = git_odb_open_rstream(&c_out, &c_len, &c_type, (git_odb *)dbPtr, &c_oid);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_odb_stream_free(c_out); */
     (*env)->CallVoidMethod(env, outType, jniConstants->midAtomicIntSet, c_type);
     (*env)->CallVoidMethod(env, len, jniConstants->midAtomicIntSet, c_len);
@@ -275,7 +275,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Odb_jniObjectDup)(JNIEnv *env, jclass obj, 
 {
     git_odb_object *c_dest = 0;
     int r = git_odb_object_dup(&c_dest, (git_odb_object *)sourcePtr);
-    (*env)->CallVoidMethod(env, dest, jniConstants->midAtomicLongSet, (long)c_dest);
+    (*env)->CallVoidMethod(env, dest, jniConstants->midAtomicLongSet, (jlong)c_dest);
     /* git_odb_object_free(c_dest); */
     return r;
 }
@@ -340,7 +340,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Odb_jniGetBackend)(JNIEnv *env, jclass obj,
 {
     git_odb_backend *c_out = 0;
     int r = git_odb_get_backend(&c_out, (git_odb *)odbPtr, pos);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_odb_backend_free(c_out); */
     return r;
 }
@@ -351,7 +351,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Odb_jniBackendPack)(JNIEnv *env, jclass obj
     git_odb_backend *c_out = 0;
     char *c_objects_dir = j_copy_of_jstring(env, objects_dir, true);
     int r = git_odb_backend_pack(&c_out, c_objects_dir);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_odb_backend_free(c_out); */
     free(c_objects_dir);
     return r;
@@ -363,7 +363,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Odb_jniBackendLoose)(JNIEnv *env, jclass ob
     git_odb_backend *c_out = 0;
     char *c_objects_dir = j_copy_of_jstring(env, objects_dir, true);
     int r = git_odb_backend_loose(&c_out, c_objects_dir, compression_level, do_fsync, dirMode, fileMode);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_odb_backend_free(c_out); */
     free(c_objects_dir);
     return r;
@@ -375,7 +375,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Odb_jniBackendOnePack)(JNIEnv *env, jclass 
     git_odb_backend *c_out = 0;
     char *c_index_file = j_copy_of_jstring(env, index_file, true);
     int r = git_odb_backend_one_pack(&c_out, c_index_file);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_odb_backend_free(c_out); */
     free(c_index_file);
     return r;

--- a/src/main/c/git24j/j_packbuilder.c
+++ b/src/main/c/git24j/j_packbuilder.c
@@ -21,7 +21,7 @@ int j_packbuilder_git_indexer_progress_cb(const git_indexer_progress *stats, voi
 }
 
 /** int git_packbuilder_new(git_packbuilder **out, git_repository *repo); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniNew)(JNIEnv *env, jclass obj, jobject out, jlong repoPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniNew)(JNIEnv *env, jclass obj, jobject out, jlong repoPtr)
 {
     git_packbuilder *c_out;
     int r = git_packbuilder_new(&c_out, (git_repository *)repoPtr);
@@ -31,14 +31,14 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniNew)(JNIEnv *env, jclass obj
 }
 
 /** unsigned int git_packbuilder_set_threads(git_packbuilder *pb, unsigned int n); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniSetThreads)(JNIEnv *env, jclass obj, jlong pbPtr, jint n)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniSetThreads)(JNIEnv *env, jclass obj, jlong pbPtr, jint n)
 {
     unsigned int r = git_packbuilder_set_threads((git_packbuilder *)pbPtr, n);
     return r;
 }
 
 /** int git_packbuilder_insert(git_packbuilder *pb, const git_oid *id, const char *name); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsert)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsert)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name)
 {
     git_oid c_id;
     j_git_oid_from_java(env, id, &c_id);
@@ -49,7 +49,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsert)(JNIEnv *env, jclass 
 }
 
 /** int git_packbuilder_insert_tree(git_packbuilder *pb, const git_oid *id); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertTree)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertTree)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id)
 {
     git_oid c_id;
     j_git_oid_from_java(env, id, &c_id);
@@ -58,7 +58,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertTree)(JNIEnv *env, jcl
 }
 
 /** int git_packbuilder_insert_commit(git_packbuilder *pb, const git_oid *id); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertCommit)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertCommit)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id)
 {
     git_oid c_id;
     j_git_oid_from_java(env, id, &c_id);
@@ -67,14 +67,14 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertCommit)(JNIEnv *env, j
 }
 
 /** int git_packbuilder_insert_walk(git_packbuilder *pb, git_revwalk *walk); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertWalk)(JNIEnv *env, jclass obj, jlong pbPtr, jlong walkPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertWalk)(JNIEnv *env, jclass obj, jlong pbPtr, jlong walkPtr)
 {
     int r = git_packbuilder_insert_walk((git_packbuilder *)pbPtr, (git_revwalk *)walkPtr);
     return r;
 }
 
 /** int git_packbuilder_insert_recur(git_packbuilder *pb, const git_oid *id, const char *name); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertRecur)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertRecur)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name)
 {
     git_oid c_id;
     j_git_oid_from_java(env, id, &c_id);
@@ -85,7 +85,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertRecur)(JNIEnv *env, jc
 }
 
 /** int git_packbuilder_write_buf(git_buf *buf, git_packbuilder *pb); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWriteBuf)(JNIEnv *env, jclass obj, jobject buf, jlong pbPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniWriteBuf)(JNIEnv *env, jclass obj, jobject buf, jlong pbPtr)
 {
     git_buf c_buf = {0};
     int r = git_packbuilder_write_buf(&c_buf, (git_packbuilder *)pbPtr);
@@ -95,7 +95,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWriteBuf)(JNIEnv *env, jclas
 }
 
 /** int git_packbuilder_write(git_packbuilder *pb, const char *path, unsigned int mode, git_indexer_progress_cb * progress_cb); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWrite)(JNIEnv *env, jclass obj, jlong pbPtr, jstring path, jint mode, jobject progressCb)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniWrite)(JNIEnv *env, jclass obj, jlong pbPtr, jstring path, jint mode, jobject progressCb)
 {
     int r;
     char *c_path = j_copy_of_jstring(env, path, true);
@@ -115,7 +115,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWrite)(JNIEnv *env, jclass o
 }
 
 /** const git_oid * git_packbuilder_hash(git_packbuilder *pb); */
-JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Packbuilder_jniHash)(JNIEnv *env, jclass obj, jlong pbPtr)
+JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(PackBuilder_jniHash)(JNIEnv *env, jclass obj, jlong pbPtr)
 {
     const git_oid *r = git_packbuilder_hash((git_packbuilder *)pbPtr);
     return j_git_oid_to_bytearray(env, r);
@@ -136,7 +136,7 @@ int j_git_packbuilder_foreach_cb(void *buf, size_t size, void *payload)
 }
 
 /** int git_packbuilder_foreach(git_packbuilder *pb, git_packbuilder_foreach_cb * cb); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniForeach)(JNIEnv *env, jclass obj, jlong pbPtr, jobject foreachCb)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniForeach)(JNIEnv *env, jclass obj, jlong pbPtr, jobject foreachCb)
 {
     j_cb_payload payload = {0};
     j_cb_payload_init(env, &payload, foreachCb, "([B)I");
@@ -146,14 +146,14 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniForeach)(JNIEnv *env, jclass
 }
 
 /** size_t git_packbuilder_object_count(git_packbuilder *pb); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniObjectCount)(JNIEnv *env, jclass obj, jlong pbPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniObjectCount)(JNIEnv *env, jclass obj, jlong pbPtr)
 {
     size_t r = git_packbuilder_object_count((git_packbuilder *)pbPtr);
     return r;
 }
 
 /** size_t git_packbuilder_written(git_packbuilder *pb); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWritten)(JNIEnv *env, jclass obj, jlong pbPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniWritten)(JNIEnv *env, jclass obj, jlong pbPtr)
 {
     size_t r = git_packbuilder_written((git_packbuilder *)pbPtr);
     return r;
@@ -172,7 +172,7 @@ int j_git_packbuilder_progress(int stage, uint32_t current, uint32_t total, void
 }
 
 /** int git_packbuilder_set_callbacks(git_packbuilder *pb, git_packbuilder_progress * progress_cb); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniSetCallbacks)(JNIEnv *env, jclass obj, jlong pbPtr, jobject progressCb)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniSetCallbacks)(JNIEnv *env, jclass obj, jlong pbPtr, jobject progressCb)
 {
     j_cb_payload *payload = (j_cb_payload *)malloc(sizeof(j_cb_payload));
     j_cb_payload_init(env, payload, progressCb, "(III)I");
@@ -181,7 +181,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniSetCallbacks)(JNIEnv *env, j
 }
 
 /** void git_packbuilder_free(git_packbuilder *pb); */
-JNIEXPORT void JNICALL J_MAKE_METHOD(Packbuilder_jniFree)(JNIEnv *env, jclass obj, jlong pbPtr)
+JNIEXPORT void JNICALL J_MAKE_METHOD(PackBuilder_jniFree)(JNIEnv *env, jclass obj, jlong pbPtr)
 {
     git_packbuilder_free((git_packbuilder *)pbPtr);
 }

--- a/src/main/c/git24j/j_packbuilder.c
+++ b/src/main/c/git24j/j_packbuilder.c
@@ -25,7 +25,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniNew)(JNIEnv *env, jclass obj
 {
     git_packbuilder *c_out;
     int r = git_packbuilder_new(&c_out, (git_repository *)repoPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_packbuilder_free(c_out); */
     return r;
 }

--- a/src/main/c/git24j/j_packbuilder.h
+++ b/src/main/c/git24j/j_packbuilder.h
@@ -10,49 +10,49 @@ extern "C"
 #endif
 
     /** int git_packbuilder_new(git_packbuilder **out, git_repository *repo); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniNew)(JNIEnv *env, jclass obj, jobject out, jlong repoPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniNew)(JNIEnv *env, jclass obj, jobject out, jlong repoPtr);
 
     /** unsigned int git_packbuilder_set_threads(git_packbuilder *pb, unsigned int n); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniSetThreads)(JNIEnv *env, jclass obj, jlong pbPtr, jint n);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniSetThreads)(JNIEnv *env, jclass obj, jlong pbPtr, jint n);
 
     /** int git_packbuilder_insert(git_packbuilder *pb, const git_oid *id, const char *name); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsert)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsert)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name);
 
     /** int git_packbuilder_insert_tree(git_packbuilder *pb, const git_oid *id); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertTree)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertTree)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id);
 
     /** int git_packbuilder_insert_commit(git_packbuilder *pb, const git_oid *id); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertCommit)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertCommit)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id);
 
     /** int git_packbuilder_insert_walk(git_packbuilder *pb, git_revwalk *walk); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertWalk)(JNIEnv *env, jclass obj, jlong pbPtr, jlong walkPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertWalk)(JNIEnv *env, jclass obj, jlong pbPtr, jlong walkPtr);
 
     /** int git_packbuilder_insert_recur(git_packbuilder *pb, const git_oid *id, const char *name); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertRecur)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertRecur)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name);
 
     /** int git_packbuilder_write_buf(git_buf *buf, git_packbuilder *pb); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWriteBuf)(JNIEnv *env, jclass obj, jobject buf, jlong pbPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniWriteBuf)(JNIEnv *env, jclass obj, jobject buf, jlong pbPtr);
 
     /** int git_packbuilder_write(git_packbuilder *pb, const char *path, unsigned int mode, git_indexer_progress_cb * progress_cb); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWrite)(JNIEnv *env, jclass obj, jlong pbPtr, jstring path, jint mode, jobject progressCb);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniWrite)(JNIEnv *env, jclass obj, jlong pbPtr, jstring path, jint mode, jobject progressCb);
 
     /** const git_oid * git_packbuilder_hash(git_packbuilder *pb); */
-    JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Packbuilder_jniHash)(JNIEnv *env, jclass obj, jlong pbPtr);
+    JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(PackBuilder_jniHash)(JNIEnv *env, jclass obj, jlong pbPtr);
 
     /** int git_packbuilder_foreach(git_packbuilder *pb, git_packbuilder_foreach_cb * cb); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniForeach)(JNIEnv *env, jclass obj, jlong pbPtr, jobject foreachCb);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniForeach)(JNIEnv *env, jclass obj, jlong pbPtr, jobject foreachCb);
 
     /** size_t git_packbuilder_object_count(git_packbuilder *pb); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniObjectCount)(JNIEnv *env, jclass obj, jlong pbPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniObjectCount)(JNIEnv *env, jclass obj, jlong pbPtr);
 
     /** size_t git_packbuilder_written(git_packbuilder *pb); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWritten)(JNIEnv *env, jclass obj, jlong pbPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniWritten)(JNIEnv *env, jclass obj, jlong pbPtr);
 
     /** int git_packbuilder_set_callbacks(git_packbuilder *pb, git_packbuilder_progress * progress_cb); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniSetCallbacks)(JNIEnv *env, jclass obj, jlong pbPtr, jobject progressCb);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniSetCallbacks)(JNIEnv *env, jclass obj, jlong pbPtr, jobject progressCb);
 
     /** void git_packbuilder_free(git_packbuilder *pb); */
-    JNIEXPORT void JNICALL J_MAKE_METHOD(Packbuilder_jniFree)(JNIEnv *env, jclass obj, jlong pbPtr);
+    JNIEXPORT void JNICALL J_MAKE_METHOD(PackBuilder_jniFree)(JNIEnv *env, jclass obj, jlong pbPtr);
 
 #ifdef __cplusplus
 }

--- a/src/main/c/git24j/j_patch.c
+++ b/src/main/c/git24j/j_patch.c
@@ -13,7 +13,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Patch_jniFromDiff)(JNIEnv *env, jclass obj,
 {
     git_patch *c_out = 0;
     int r = git_patch_from_diff(&c_out, (git_diff *)diffPtr, idx);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -24,7 +24,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Patch_jniFromBlobs)(JNIEnv *env, jclass obj
     char *c_old_as_path = j_copy_of_jstring(env, old_as_path, true);
     char *c_new_as_path = j_copy_of_jstring(env, new_as_path, true);
     int r = git_patch_from_blobs(&c_out, (git_blob *)oldBlobPtr, c_old_as_path, (git_blob *)newBlobPtr, c_new_as_path, (git_diff_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_old_as_path);
     free(c_new_as_path);
     return r;
@@ -39,7 +39,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Patch_jniFromBlobAndBuffer)(JNIEnv *env, jc
     unsigned char *c_buffer = j_unsigned_chars_from_java(env, buffer, &buffer_len);
     char *c_buffer_as_path = j_copy_of_jstring(env, buffer_as_path, true);
     int r = git_patch_from_blob_and_buffer(&c_out, (git_blob *)oldBlobPtr, c_old_as_path, (void *)c_buffer, bufferLen, c_buffer_as_path, (git_diff_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_old_as_path);
     (*env)->ReleaseByteArrayElements(env, buffer, (jbyte *)c_buffer, 0);
     free(c_buffer_as_path);
@@ -57,7 +57,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Patch_jniFromBuffers)(JNIEnv *env, jclass o
     unsigned char *c_new_buffer = j_unsigned_chars_from_java(env, newBuffer, &new_buffer_len);
     char *c_new_as_path = j_copy_of_jstring(env, new_as_path, true);
     int r = git_patch_from_buffers(&c_out, (void *)c_old_buffer, oldLen, c_old_as_path, (void *)c_new_buffer, newLen, c_new_as_path, (git_diff_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     (*env)->ReleaseByteArrayElements(env, oldBuffer, (jbyte *)c_old_buffer, 0);
     free(c_old_as_path);
     (*env)->ReleaseByteArrayElements(env, newBuffer, (jbyte *)c_new_buffer, 0);
@@ -104,7 +104,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Patch_jniGetHunk)(JNIEnv *env, jclass obj, 
     const git_diff_hunk *c_out = 0;
     size_t c_lines_in_hunk;
     int r = git_patch_get_hunk(&c_out, &c_lines_in_hunk, (git_patch *)patchPtr, hunkIdx);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     (*env)->CallVoidMethod(env, linesInHunk, jniConstants->midAtomicIntSet, c_lines_in_hunk);
     return r;
 }
@@ -121,7 +121,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Patch_jniGetLineInHunk)(JNIEnv *env, jclass
 {
     const git_diff_line *c_out = 0;
     int r = git_patch_get_line_in_hunk(&c_out, (git_patch *)patchPtr, hunkIdx, lineOfHunk);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 /** size_t git_patch_size(git_patch *patch, int include_context, int include_hunk_headers, int include_file_headers); */

--- a/src/main/c/git24j/j_pathspec.c
+++ b/src/main/c/git24j/j_pathspec.c
@@ -16,7 +16,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Pathspec_jniNew)(JNIEnv *env, jclass obj, j
     git_strarray c_pathspec;
     git_strarray_of_jobject_array(env, pathspec, &c_pathspec);
     int r = git_pathspec_new(&c_out, &c_pathspec);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_pathspec_free(c_out); */
     git_strarray_free(&c_pathspec);
     return r;
@@ -42,7 +42,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Pathspec_jniMatchWorkdir)(JNIEnv *env, jcla
 {
     git_pathspec_match_list *c_out;
     int r = git_pathspec_match_workdir(&c_out, (git_repository *)repoPtr, flags, (git_pathspec *)psPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_pathspec_match_list_free(c_out); */
     return r;
 }
@@ -52,7 +52,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Pathspec_jniMatchIndex)(JNIEnv *env, jclass
 {
     git_pathspec_match_list *c_out;
     int r = git_pathspec_match_index(&c_out, (git_index *)indexPtr, flags, (git_pathspec *)psPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_pathspec_match_list_free(c_out); */
     return r;
 }
@@ -62,7 +62,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Pathspec_jniMatchTree)(JNIEnv *env, jclass 
 {
     git_pathspec_match_list *c_out;
     int r = git_pathspec_match_tree(&c_out, (git_tree *)treePtr, flags, (git_pathspec *)psPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_pathspec_match_list_free(c_out); */
     return r;
 }
@@ -72,7 +72,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Pathspec_jniMatchDiff)(JNIEnv *env, jclass 
 {
     git_pathspec_match_list *c_out;
     int r = git_pathspec_match_diff(&c_out, (git_diff *)diffPtr, flags, (git_pathspec *)psPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_pathspec_match_list_free(c_out); */
     return r;
 }

--- a/src/main/c/git24j/j_proxy.c
+++ b/src/main/c/git24j/j_proxy.c
@@ -51,7 +51,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Proxy_jniOptionsNew)(JNIEnv *env, jclass ob
     opts->url = NULL;
     opts->payload = NULL;
     j_git_proxy_options_init_payload(opts);
-    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 

--- a/src/main/c/git24j/j_rebase.c
+++ b/src/main/c/git24j/j_rebase.c
@@ -13,7 +13,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Rebase_jniInit)(JNIEnv *env, jclass obj, jo
 {
     git_rebase *c_out = 0;
     int r = git_rebase_init(&c_out, (git_repository *)repoPtr, (git_annotated_commit *)branchPtr, (git_annotated_commit *)upstreamPtr, (git_annotated_commit *)ontoPtr, (git_rebase_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -22,7 +22,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Rebase_jniOpen)(JNIEnv *env, jclass obj, jo
 {
     git_rebase *c_out = 0;
     int r = git_rebase_open(&c_out, (git_repository *)repoPtr, (git_rebase_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -52,7 +52,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Rebase_jniNext)(JNIEnv *env, jclass obj, jo
 {
     git_rebase_operation *c_operation = 0;
     int r = git_rebase_next(&c_operation, (git_rebase *)rebasePtr);
-    (*env)->CallVoidMethod(env, operation, jniConstants->midAtomicLongSet, (long)c_operation);
+    (*env)->CallVoidMethod(env, operation, jniConstants->midAtomicLongSet, (jlong)c_operation);
     return r;
 }
 
@@ -61,7 +61,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Rebase_jniInmemoryIndex)(JNIEnv *env, jclas
 {
     git_index *c_index = 0;
     int r = git_rebase_inmemory_index(&c_index, (git_rebase *)rebasePtr);
-    (*env)->CallVoidMethod(env, index, jniConstants->midAtomicLongSet, (long)c_index);
+    (*env)->CallVoidMethod(env, index, jniConstants->midAtomicLongSet, (jlong)c_index);
     return r;
 }
 
@@ -166,7 +166,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Rebase_jniOptionsNew)(JNIEnv *env, jclass o
     git_rebase_options *opts = (git_rebase_options *)malloc(sizeof(git_rebase_options));
     int r = git_rebase_init_options(opts, version);
     opts->rewrite_notes_ref = NULL;
-    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 

--- a/src/main/c/git24j/j_rebase.h
+++ b/src/main/c/git24j/j_rebase.h
@@ -94,6 +94,8 @@ extern "C"
     /** git_commit_signing_cb signing_cb*/
     JNIEXPORT void JNICALL J_MAKE_METHOD(Rebase_jniOptionsSetSigningCb)(JNIEnv *env, jclass obj, jlong optionsPtr, jobject signingCb);
 
+    JNIEXPORT void JNICALL J_MAKE_METHOD(Rebase_jniOptionsSetPayload)(JNIEnv *env, jclass obj, jlong optionsPtr, jlong payload);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main/c/git24j/j_refdb.c
+++ b/src/main/c/git24j/j_refdb.c
@@ -14,7 +14,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Refdb_jniNew)(JNIEnv *env, jclass obj, jobj
 {
     git_refdb *c_out;
     int r = git_refdb_new(&c_out, (git_repository *)repoPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -23,7 +23,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Refdb_jniOpen)(JNIEnv *env, jclass obj, job
 {
     git_refdb *c_out;
     int r = git_refdb_open(&c_out, (git_repository *)repoPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 

--- a/src/main/c/git24j/j_reference.c
+++ b/src/main/c/git24j/j_reference.c
@@ -13,7 +13,7 @@ const size_t MAX_REF_NAME_SIZE = 32768;
 
 /**
  * int git_reference_foreach_cb(git_reference *reference, void *payload);
- * 
+ *
  * Consumer accept long as git_reference ptr and return integer
  *  */
 int j_git_reference_foreach_cb(git_reference *reference, void *payload)
@@ -31,7 +31,7 @@ int j_git_reference_foreach_cb(git_reference *reference, void *payload)
         return 0;
     }
     JNIEnv *env = getEnv();
-    int r = (*env)->CallIntMethod(env, callback, mid, (long)reference);
+    int r = (*env)->CallIntMethod(env, callback, mid, (jlong)reference);
     return r;
 }
 /**int git_reference_foreach_name_cb(const char *name, void *payload); */
@@ -58,7 +58,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniLookup)(JNIEnv *env, jclass ob
     git_reference *out_ref = 0;
     char *c_name = j_copy_of_jstring(env, name, false);
     int e = git_reference_lookup(&out_ref, (git_repository *)repoPtr, c_name);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)out_ref);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)out_ref);
     free(c_name);
     return e;
 }
@@ -79,7 +79,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniDwim)(JNIEnv *env, jclass obj,
     char *short_hand = j_copy_of_jstring(env, shorthand, false);
     int e = git_reference_dwim(&out_ref, (git_repository *)repoPtr, short_hand);
     free(short_hand);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)out_ref);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)out_ref);
     return e;
 }
 /**int git_reference_symbolic_create_matching(git_reference **out, git_repository *repo, const char *name, const char *target, int force, const char *current_value, const char *log_message); */
@@ -91,7 +91,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniSymbolicCreateMatching)(JNIEnv
     char *current_value = j_copy_of_jstring(env, currentValue, true);
     char *log_message = j_copy_of_jstring(env, logMessage, true);
     int e = git_reference_symbolic_create_matching(&c_out, (git_repository *)repoPtr, c_name, c_target, force, current_value, log_message);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(log_message);
     free(current_value);
     free(c_target);
@@ -106,7 +106,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniSymbolicCreate)(JNIEnv *env, j
     char *c_target = j_copy_of_jstring(env, target, false);
     char *log_message = j_copy_of_jstring(env, logMessage, true);
     int e = git_reference_symbolic_create(&c_out, (git_repository *)repoPtr, c_name, c_target, force, log_message);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(log_message);
     free(c_target);
     free(c_name);
@@ -121,7 +121,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniCreate)(JNIEnv *env, jclass ob
     char *c_name = j_copy_of_jstring(env, name, false);
     char *log_message = j_copy_of_jstring(env, logMessage, true);
     int e = git_reference_create(&c_out, (git_repository *)repoPtr, c_name, &c_oid, force, log_message);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(log_message);
     free(c_name);
     return e;
@@ -143,7 +143,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniCreateMatching)(JNIEnv *env, j
 
     // int e = git_reference_create_matching(&c_out, (git_repository *)repoPtr, c_name, &c_oid, force, &current_id, log_message);
     int e = git_reference_create_matching(&c_out, (git_repository *)repoPtr, c_name, &c_oid, force, current_id, log_message);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_name);
     free(log_message);
     free(current_id);
@@ -183,7 +183,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniResolve)(JNIEnv *env, jclass o
 {
     git_reference *c_out = 0;
     int e = git_reference_resolve(&c_out, (git_reference *)refPtr);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_out);
     return e;
 }
 /**git_repository * git_reference_owner(const git_reference *ref); */
@@ -198,7 +198,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniSymbolicSetTarget)(JNIEnv *env
     char *c_target = j_copy_of_jstring(env, target, false);
     char *log_message = j_copy_of_jstring(env, logMessage, false);
     int e = git_reference_symbolic_set_target(&c_out, (git_reference *)refPtr, c_target, log_message);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_target);
     free(log_message);
     return e;
@@ -211,18 +211,18 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniSetTarget)(JNIEnv *env, jclass
     j_git_oid_from_java(env, oid, &c_oid);
     char *log_message = j_copy_of_jstring(env, logMessage, true);
     int e = git_reference_set_target(&c_out, (git_reference *)refPtr, &c_oid, log_message);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(log_message);
     return e;
 }
 /**int git_reference_rename(git_reference **new_ref, git_reference *ref, const char *new_name, int force, const char *log_message); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniRename)(JNIEnv *env, jclass obj, jobject outRef, jlong refPtr, jstring newName, int force, jstring logMessage)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniRename)(JNIEnv *env, jclass obj, jobject outRef, jlong refPtr, jstring newName, jint force, jstring logMessage)
 {
     git_reference *new_ref = 0;
     char *new_name = j_copy_of_jstring(env, newName, false);
     char *log_message = j_copy_of_jstring(env, logMessage, true);
     int e = git_reference_rename(&new_ref, (git_reference *)refPtr, new_name, force, log_message);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)new_ref);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)new_ref);
     free(log_message);
     free(new_name);
     return e;
@@ -273,7 +273,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniDup)(JNIEnv *env, jclass obj, 
 {
     git_reference *dest = 0;
     int e = git_reference_dup(&dest, (git_reference *)sourcePtr);
-    (*env)->CallVoidMethod(env, outDest, jniConstants->midAtomicLongSet, (long)dest);
+    (*env)->CallVoidMethod(env, outDest, jniConstants->midAtomicLongSet, (jlong)dest);
     return e;
 }
 /**void git_reference_free(git_reference *ref); */
@@ -291,7 +291,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniIteratorNew)(JNIEnv *env, jcla
 {
     git_reference_iterator *c_out = 0;
     int e = git_reference_iterator_new(&c_out, (git_repository *)repoPtr);
-    (*env)->CallVoidMethod(env, outIter, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outIter, jniConstants->midAtomicLongSet, (jlong)c_out);
     return e;
 }
 /**int git_reference_iterator_glob_new(git_reference_iterator **out, git_repository *repo, const char *glob); */
@@ -300,7 +300,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniIteratorGlobNew)(JNIEnv *env, 
     git_reference_iterator *c_out = 0;
     char *c_glob = j_copy_of_jstring(env, glob, false);
     int e = git_reference_iterator_glob_new(&c_out, (git_repository *)repoPtr, c_glob);
-    (*env)->CallVoidMethod(env, outIter, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outIter, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_glob);
     return e;
 }
@@ -309,7 +309,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniNext)(JNIEnv *env, jclass obj,
 {
     git_reference *c_out = 0;
     int e = git_reference_next(&c_out, (git_reference_iterator *)iterPtr);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_out);
     return e;
 }
 /**int git_reference_next_name(const char **out, git_reference_iterator *iter); */
@@ -382,7 +382,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniIsNote)(JNIEnv *env, jclass ob
 }
 
 /**
- * Call git_reference_normalize_name with auto increasing buffer. 
+ * Call git_reference_normalize_name with auto increasing buffer.
  * Note: out_name must be free-ed after the call, *out_size must start with 0 and *out_name should start with NULL
  * */
 int _git_reference_normalize_name_dynamic(char **out_name, size_t *out_size, const char *name, int flags)
@@ -432,7 +432,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniPeel)(JNIEnv *env, jclass obj,
 {
     git_object *c_out = 0;
     int e = git_reference_peel(&c_out, (git_reference *)refPtr, (git_object_t)objType);
-    (*env)->CallVoidMethod(env, outObj, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outObj, jniConstants->midAtomicLongSet, (jlong)c_out);
     return e;
 }
 /**int git_reference_is_valid_name(const char *refname); */

--- a/src/main/c/git24j/j_reference.h
+++ b/src/main/c/git24j/j_reference.h
@@ -42,7 +42,7 @@ extern "C"
     /**int git_reference_set_target(git_reference **out, git_reference *ref, const git_oid *id, const char *log_message); */
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniSetTarget)(JNIEnv *env, jclass obj, jobject outRef, jlong refPtr, jobject oid, jstring logMessage);
     /**int git_reference_rename(git_reference **new_ref, git_reference *ref, const char *new_name, int force, const char *log_message); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniRename)(JNIEnv *env, jclass obj, jobject outRef, jlong refPtr, jstring newName, int force, jstring logMessage);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniRename)(JNIEnv *env, jclass obj, jobject outRef, jlong refPtr, jstring newName, jint force, jstring logMessage);
     /**int git_reference_delete(git_reference *ref); */
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Reference_jniDelete)(JNIEnv *env, jclass obj, jlong refPtr);
     /**int git_reference_remove(git_repository *repo, const char *name); */

--- a/src/main/c/git24j/j_reflog.c
+++ b/src/main/c/git24j/j_reflog.c
@@ -15,7 +15,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Reflog_jniRead)(JNIEnv *env, jclass obj, jo
     git_reflog *c_out;
     char *c_name = j_copy_of_jstring(env, name, true);
     int r = git_reflog_read(&c_out, (git_repository *)repoPtr, c_name);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_reflog_free(c_out); */
     free(c_name);
     return r;

--- a/src/main/c/git24j/j_refspec.c
+++ b/src/main/c/git24j/j_refspec.c
@@ -14,7 +14,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Refspec_jniParse)(JNIEnv *env, jclass obj, 
     git_refspec *c_refspec = 0;
     char *c_input = j_copy_of_jstring(env, input, true);
     int r = git_refspec_parse(&c_refspec, c_input, is_fetch);
-    (*env)->CallVoidMethod(env, refspec, jniConstants->midAtomicLongSet, (long)c_refspec);
+    (*env)->CallVoidMethod(env, refspec, jniConstants->midAtomicLongSet, (jlong)c_refspec);
     /* git_refspec_free(c_refspec); */
     free(c_input);
     return r;

--- a/src/main/c/git24j/j_remote.c
+++ b/src/main/c/git24j/j_remote.c
@@ -492,14 +492,14 @@ JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniCallbacksTest)(JNIEnv *env, jclas
     cb->resolve_url(NULL, "resolve_url.url", 1, payload);
 }
 
-JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniCallbacksSetCallbackObject)(JNIEnv *env, jclass obj, jlong cbsPtr, jobject cbsObject, j_callback_type_t cbt)
+JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniCallbacksSetCallbackObject)(JNIEnv *env, jclass obj, jlong cbsPtr, jobject cbsObject, jint cbt)
 {
     git_remote_callbacks *cb = (git_remote_callbacks *)cbsPtr;
     if (cb->payload == NULL)
     {
         cb->payload = (*env)->NewGlobalRef(env, cbsObject);
     }
-    assert(cbt <= J_REMOTE_CALLBACK_URL_RESOLVE && "unrecognized callbacks type");
+    assert((cbt >= J_REMOTE_CALLBACK_CRED && cbt <= J_REMOTE_CALLBACK_URL_RESOLVE) && "unrecognized callbacks type");
     switch (cbt)
     {
     case J_REMOTE_CALLBACK_CRED:
@@ -782,7 +782,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniFetchOptionsNew)(JNIEnv *env, jcl
     (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
-JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniFetchOptionsFree)(JNIEnv *env, jclass obj, jobject optsPtr)
+JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniFetchOptionsFree)(JNIEnv *env, jclass obj, jlong optsPtr)
 {
     git_fetch_options *opts = (git_fetch_options *)optsPtr;
     if (opts->callbacks.payload != NULL)
@@ -891,7 +891,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniPushOptionsNew)(JNIEnv *env, jcla
     (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
-JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniPushOptionsFree)(JNIEnv *env, jclass obj, jobject optsPtr)
+JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniPushOptionsFree)(JNIEnv *env, jclass obj, jlong optsPtr)
 {
     git_push_options *opts = (git_push_options *)optsPtr;
     if (opts->callbacks.payload != NULL)

--- a/src/main/c/git24j/j_remote.c
+++ b/src/main/c/git24j/j_remote.c
@@ -443,9 +443,9 @@ JNIEXPORT jlong JNICALL J_MAKE_METHOD(Remote_jniGetRefspec)(JNIEnv *env, jclass 
 }
 
 /** int git_remote_init_callbacks(git_remote_callbacks *opts, unsigned int version); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniInitCallbacks)(JNIEnv *env, jclass obj, jlong optsPtr, jint version)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniInitCallbacks)(JNIEnv *env, jclass obj, jlong remoteCallbacksPtr, jint version)
 {
-    int r = git_remote_init_callbacks((git_remote_callbacks *)optsPtr, version);
+    int r = git_remote_init_callbacks((git_remote_callbacks *)remoteCallbacksPtr, version);
     return r;
 }
 

--- a/src/main/c/git24j/j_remote.c
+++ b/src/main/c/git24j/j_remote.c
@@ -951,6 +951,19 @@ JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniPushOptionsSetCustomHeaders)(JNIE
     j_strarray_from_java(env, c_array, customHeaders);
 }
 
+JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniPushOptionsSetRemotePushOptions)(JNIEnv *env, jclass obj, jlong pushOptionsPtr, jobjectArray remotePushOptions)
+{
+    git_strarray *c_array = &(((git_push_options *)pushOptionsPtr)->remote_push_options);
+    j_strarray_from_java(env, c_array, remotePushOptions);
+}
+
+JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniPushOptionsGetRemotePushOptions)(JNIEnv *env, jclass obj, jlong pushOptionsPtr, jobject outRemotePushOptions)
+{
+    git_strarray *c_array = &(((git_push_options *)pushOptionsPtr)->remote_push_options);
+    j_strarray_to_java_list(env, c_array, outRemotePushOptions);
+}
+
+
 /** -------- Wrapper Body ---------- */
 JNIEXPORT jlong JNICALL J_MAKE_METHOD(Remote_jniPushUpdateNew)(JNIEnv *env, jclass obj)
 {

--- a/src/main/c/git24j/j_remote.c
+++ b/src/main/c/git24j/j_remote.c
@@ -616,7 +616,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniPush)(JNIEnv *env, jclass obj, jl
 JNIEXPORT jstring JNICALL J_MAKE_METHOD(Remote_jniPushurl)(JNIEnv *env, jclass obj, jlong remotePtr)
 {
     const char *r = git_remote_pushurl((git_remote *)remotePtr);
-    return (*env)->NewStringUTF(env, r);
+    return r ? (*env)->NewStringUTF(env, r) : NULL;
 }
 
 /** size_t git_remote_refspec_count(const git_remote *remote); */
@@ -708,7 +708,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniUpload)(JNIEnv *env, jclass obj, 
 JNIEXPORT jstring JNICALL J_MAKE_METHOD(Remote_jniUrl)(JNIEnv *env, jclass obj, jlong remotePtr)
 {
     const char *r = git_remote_url((git_remote *)remotePtr);
-    return (*env)->NewStringUTF(env, r);
+    return r ? (*env)->NewStringUTF(env, r) : NULL;
 }
 
 /** -------- Wrapper Body ---------- */

--- a/src/main/c/git24j/j_remote.c
+++ b/src/main/c/git24j/j_remote.c
@@ -88,7 +88,7 @@ int j_git_transport_certificate_check_cb(git_cert *cert, int valid, const char *
     }
     JNIEnv *env = getEnv();
     jstring jHost = (*env)->NewStringUTF(env, host);
-    int r = (*env)->CallIntMethod(env, (jobject)payload, jniConstants->remote.midTransportCertificateCheck, (long)cert, valid, jHost);
+    int r = (*env)->CallIntMethod(env, (jobject)payload, jniConstants->remote.midTransportCertificateCheck, (jlong)cert, valid, jHost);
     (*env)->DeleteLocalRef(env, jHost);
     return r;
 }
@@ -100,7 +100,7 @@ int j_git_transfer_progress_cb(const git_transfer_progress *stats, void *payload
         return 0;
     }
     JNIEnv *env = getEnv();
-    int r = (*env)->CallIntMethod(env, (jobject)payload, jniConstants->remote.midTransferProgress, (long)stats);
+    int r = (*env)->CallIntMethod(env, (jobject)payload, jniConstants->remote.midTransferProgress, (jlong)stats);
     return r;
 }
 
@@ -187,7 +187,7 @@ int j_git_transport_cb(git_transport **out, git_remote *owner, void *payload)
         return 0;
     }
     JNIEnv *env = getEnv();
-    long res = (*env)->CallIntMethod(env, (jobject)payload, jniConstants->remote.midTransport, (long)owner);
+    long res = (*env)->CallIntMethod(env, (jobject)payload, jniConstants->remote.midTransport, (jlong)owner);
     if (res > 0)
     {
         *out = (git_transport *)res;
@@ -267,7 +267,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniCreate)(JNIEnv *env, jclass obj, 
     char *c_name = j_copy_of_jstring(env, name, true);
     char *c_url = j_copy_of_jstring(env, url, true);
     int r = git_remote_create(&c_out, (git_repository *)repoPtr, c_name, c_url);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_name);
     free(c_url);
     return r;
@@ -279,7 +279,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniCreateAnonymous)(JNIEnv *env, jcl
     git_remote *c_out = 0;
     char *c_url = j_copy_of_jstring(env, url, true);
     int r = git_remote_create_anonymous(&c_out, (git_repository *)repoPtr, c_url);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_url);
     return r;
 }
@@ -290,7 +290,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniCreateDetached)(JNIEnv *env, jcla
     git_remote *c_out = 0;
     char *c_url = j_copy_of_jstring(env, url, true);
     int r = git_remote_create_detached(&c_out, c_url);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_url);
     return r;
 }
@@ -306,7 +306,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniCreateOptionsNew)(JNIEnv *env, jc
 {
     git_remote_create_options *opts = (git_remote_create_options *)malloc(sizeof(git_remote_create_options));
     int r = git_remote_create_init_options(opts, version);
-    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 
@@ -326,7 +326,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniCreateWithFetchspec)(JNIEnv *env,
     char *c_url = j_copy_of_jstring(env, url, true);
     char *c_fetch = j_copy_of_jstring(env, fetch, true);
     int r = git_remote_create_with_fetchspec(&c_out, (git_repository *)repoPtr, c_name, c_url, c_fetch);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_name);
     free(c_url);
     free(c_fetch);
@@ -339,7 +339,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniCreateWithOpts)(JNIEnv *env, jcla
     git_remote *c_out = 0;
     char *c_url = j_copy_of_jstring(env, url, true);
     int r = git_remote_create_with_opts(&c_out, c_url, (git_remote_create_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_url);
     return r;
 }
@@ -384,7 +384,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniDup)(JNIEnv *env, jclass obj, job
 {
     git_remote *c_dest = 0;
     int r = git_remote_dup(&c_dest, (git_remote *)sourcePtr);
-    (*env)->CallVoidMethod(env, dest, jniConstants->midAtomicLongSet, (long)c_dest);
+    (*env)->CallVoidMethod(env, dest, jniConstants->midAtomicLongSet, (jlong)c_dest);
     return r;
 }
 
@@ -453,7 +453,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniCallbacksNew)(JNIEnv *env, jclass
 {
     git_remote_callbacks *cb = (git_remote_callbacks *)malloc(sizeof(git_remote_callbacks));
     int r = git_remote_init_callbacks((git_remote_callbacks *)cb, version);
-    (*env)->CallVoidMethod(env, outCb, jniConstants->midAtomicLongSet, (long)cb);
+    (*env)->CallVoidMethod(env, outCb, jniConstants->midAtomicLongSet, (jlong)cb);
     return r;
 }
 
@@ -569,7 +569,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniLookup)(JNIEnv *env, jclass obj, 
     git_remote *c_out = 0;
     char *c_name = j_copy_of_jstring(env, name, true);
     int r = git_remote_lookup(&c_out, (git_repository *)repoPtr, c_name);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_name);
     return r;
 }
@@ -779,7 +779,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniFetchOptionsNew)(JNIEnv *env, jcl
 {
     git_fetch_options *opts = (git_fetch_options *)malloc(sizeof(git_fetch_options));
     int r = git_fetch_init_options(opts, version);
-    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniFetchOptionsFree)(JNIEnv *env, jclass obj, jobject optsPtr)
@@ -888,7 +888,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniPushOptionsNew)(JNIEnv *env, jcla
 {
     git_push_options *opts = (git_push_options *)malloc(sizeof(git_push_options));
     int r = git_push_options_init(opts, version);
-    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniPushOptionsFree)(JNIEnv *env, jclass obj, jobject optsPtr)

--- a/src/main/c/git24j/j_remote.h
+++ b/src/main/c/git24j/j_remote.h
@@ -80,7 +80,7 @@ extern "C"
     JNIEXPORT jlong JNICALL J_MAKE_METHOD(Remote_jniGetRefspec)(JNIEnv *env, jclass obj, jlong remotePtr, jint n);
 
     /** int git_remote_init_callbacks(git_remote_callbacks *opts, unsigned int version); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniInitCallbacks)(JNIEnv *env, jclass obj, jlong optsPtr, jint version);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniInitCallbacks)(JNIEnv *env, jclass obj, jlong remoteCallbacksPtr, jint version);
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniCallbacksNew)(JNIEnv *env, jclass obj, jobject outCb, jint version);
     JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniCallbacksFree)(JNIEnv *env, jclass obj, jlong cbsPtr);
     JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniCallbacksTest)(JNIEnv *env, jclass obj, jlong cbsPtr, jobject cbsObject);

--- a/src/main/c/git24j/j_remote.h
+++ b/src/main/c/git24j/j_remote.h
@@ -101,7 +101,7 @@ extern "C"
     } j_callback_type_t;
 
     /** set transport_message_cb */
-    JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniCallbacksSetCallbackObject)(JNIEnv *env, jclass obj, jlong cbsPtr, jobject cbsObject, j_callback_type_t cbt);
+    JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniCallbacksSetCallbackObject)(JNIEnv *env, jclass obj, jlong cbsPtr, jobject cbsObject, jint cbt);
 
     /** int git_remote_is_valid_name(const char *remote_name); */
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniIsValidName)(JNIEnv *env, jclass obj, jstring remote_name);
@@ -184,7 +184,7 @@ extern "C"
 
     /** -------- structure_git_remote_fetch_options ---------- */
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniFetchOptionsNew)(JNIEnv *env, jclass obj, jobject outPtr, jint version);
-    JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniFetchOptionsFree)(JNIEnv *env, jclass obj, jobject optsPtr);
+    JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniFetchOptionsFree)(JNIEnv *env, jclass obj, jlong optsPtr);
     /** int version*/
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniFetchOptionsGetVersion)(JNIEnv *env, jclass obj, jlong fetchOptionsPtr);
     /** git_remote_callbacks callbacks*/
@@ -222,7 +222,7 @@ extern "C"
 
     /** -------- git_push_options ---------- */
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniPushOptionsNew)(JNIEnv *env, jclass obj, jobject outPtr, jint version);
-    JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniPushOptionsFree)(JNIEnv *env, jclass obj, jobject optsPtr);
+    JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniPushOptionsFree)(JNIEnv *env, jclass obj, jlong optsPtr);
     /** unsigned int version*/
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniPushOptionsGetVersion)(JNIEnv *env, jclass obj, jlong pushOptionsPtr);
     /** unsigned int pb_parallelism*/

--- a/src/main/c/git24j/j_remote.h
+++ b/src/main/c/git24j/j_remote.h
@@ -240,6 +240,10 @@ extern "C"
     /** git_strarray custom_headers*/
     JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniPushOptionsSetCustomHeaders)(JNIEnv *env, jclass obj, jlong pushOptionsPtr, jobjectArray customHeaders);
 
+    /** git_strarray remote_push_options*/
+    JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniPushOptionsSetRemotePushOptions)(JNIEnv *env, jclass obj, jlong pushOptionsPtr, jobjectArray remotePushOptions);
+    JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniPushOptionsGetRemotePushOptions)(JNIEnv *env, jclass obj, jlong pushOptionsPtr, jobject outRemotePushOptions);
+
     /** -------- Signature of the header ---------- */
     JNIEXPORT jlong JNICALL J_MAKE_METHOD(Remote_jniPushUpdateNew)(JNIEnv *env, jclass obj);
     JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniPushUpdateFree)(JNIEnv *env, jclass obj, jlong pushUpdatePtr);

--- a/src/main/c/git24j/j_repository.c
+++ b/src/main/c/git24j/j_repository.c
@@ -18,7 +18,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniOpen)(JNIEnv *env, jclass obj
 
     char *c_path = j_copy_of_jstring(env, path, false);
     int error = git_repository_open(&repo, c_path);
-    (*env)->CallVoidMethod(env, ptrReceiver, jniConstants->midAtomicLongSet, (long)repo);
+    (*env)->CallVoidMethod(env, ptrReceiver, jniConstants->midAtomicLongSet, (jlong)repo);
     free(c_path);
     return error;
 }
@@ -28,7 +28,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniOpenFromWorkTree)(JNIEnv *env
     git_repository *repo = NULL;
     git_worktree *c_wt = (git_worktree *)wtPtr;
     int error = git_repository_open_from_worktree(&repo, c_wt);
-    (*env)->CallVoidMethod(env, ptrReceiver, jniConstants->midAtomicLongSet, (long)repo);
+    (*env)->CallVoidMethod(env, ptrReceiver, jniConstants->midAtomicLongSet, (jlong)repo);
     return error;
 }
 
@@ -37,7 +37,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniWrapOdb)(JNIEnv *env, jclass 
     git_repository *repo = NULL;
     git_odb *c_odb = (git_odb *)odbPtr;
     int error = git_repository_wrap_odb(&repo, c_odb);
-    (*env)->CallVoidMethod(env, ptrReceiver, jniConstants->midAtomicLongSet, (long)repo);
+    (*env)->CallVoidMethod(env, ptrReceiver, jniConstants->midAtomicLongSet, (jlong)repo);
     return error;
 }
 
@@ -66,7 +66,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniOpenExt)(JNIEnv *env, jclass 
     char *c_ceilingDirs = j_copy_of_jstring(env, ceilingDirs, true);
     int error = git_repository_open_ext(&repo, c_path, flags, c_ceilingDirs);
 
-    (*env)->CallVoidMethod(env, ptrReceiver, jniConstants->midAtomicLongSet, (long)repo);
+    (*env)->CallVoidMethod(env, ptrReceiver, jniConstants->midAtomicLongSet, (jlong)repo);
     free(c_ceilingDirs);
     free(c_path);
     return error;
@@ -78,7 +78,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniOpenBare)(JNIEnv *env, jclass
     char *c_path = j_copy_of_jstring(env, path, false);
 
     int error = git_repository_open_bare(&repo, c_path);
-    (*env)->CallVoidMethod(env, ptrReceiver, jniConstants->midAtomicLongSet, (long)repo);
+    (*env)->CallVoidMethod(env, ptrReceiver, jniConstants->midAtomicLongSet, (jlong)repo);
     free(c_path);
     return error;
 }
@@ -94,7 +94,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniInit)(JNIEnv *env, jclass obj
     git_repository *repo = NULL;
     char *c_path = j_copy_of_jstring(env, path, false);
     int error = git_repository_init(&repo, c_path, (unsigned int)isBare);
-    (*env)->CallVoidMethod(env, outRepo, jniConstants->midAtomicLongSet, (long)repo);
+    (*env)->CallVoidMethod(env, outRepo, jniConstants->midAtomicLongSet, (jlong)repo);
     free(c_path);
     return error;
 }
@@ -226,7 +226,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniInitOptionsNew)(JNIEnv *env, 
 {
     git_repository_init_options *c_opts = (git_repository_init_options *)malloc(sizeof(git_repository_init_options));
     int e = git_repository_init_init_options(c_opts, version);
-    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (long)c_opts);
+    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (jlong)c_opts);
     return e;
 }
 
@@ -239,7 +239,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniInitExt)(JNIEnv *env, jclass 
     git_repository_init_options init_opts;
     init_options_copy_from_java(env, initOpts, &init_opts);
     int error = git_repository_init_ext(&repo, repo_path, &init_opts);
-    (*env)->CallVoidMethod(env, outRepo, jniConstants->midAtomicLongSet, (long)repo);
+    (*env)->CallVoidMethod(env, outRepo, jniConstants->midAtomicLongSet, (jlong)repo);
     git_repository_init_options_clear(env, &init_opts);
     free(repo_path);
     return error;
@@ -260,7 +260,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniHeadForWorktree)(JNIEnv *env,
     char *c_name = j_copy_of_jstring(env, name, false);
     git_reference *c_ref;
     int error = git_repository_head_for_worktree(&c_ref, c_repo, c_name);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_repo);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_repo);
     free(c_name);
     return error;
 }
@@ -333,7 +333,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniConfig)(JNIEnv *env, jclass o
 {
     git_config *c_config = 0;
     int e = git_repository_config(&c_config, (git_repository *)repoPtr);
-    (*env)->CallVoidMethod(env, outConfig, jniConstants->midAtomicLongSet, (long)c_config);
+    (*env)->CallVoidMethod(env, outConfig, jniConstants->midAtomicLongSet, (jlong)c_config);
     return e;
 }
 
@@ -341,7 +341,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniConfigSnapshot)(JNIEnv *env, 
 {
     git_config *c_config = 0;
     int e = git_repository_config_snapshot(&c_config, (git_repository *)repoPtr);
-    (*env)->CallVoidMethod(env, outConfig, jniConstants->midAtomicLongSet, (long)c_config);
+    (*env)->CallVoidMethod(env, outConfig, jniConstants->midAtomicLongSet, (jlong)c_config);
     return e;
 }
 
@@ -349,7 +349,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniOdb)(JNIEnv *env, jclass obj,
 {
     git_odb *c_odb = 0;
     int e = git_repository_odb(&c_odb, (git_repository *)repoPtr);
-    (*env)->CallVoidMethod(env, outOdb, jniConstants->midAtomicLongSet, (long)c_odb);
+    (*env)->CallVoidMethod(env, outOdb, jniConstants->midAtomicLongSet, (jlong)c_odb);
     return e;
 }
 
@@ -358,7 +358,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniRefdb)(JNIEnv *env, jclass ob
 {
     git_refdb *c_refdb = 0;
     int e = git_repository_refdb(&c_refdb, (git_repository *)repoPtr);
-    (*env)->CallVoidMethod(env, outRefdb, jniConstants->midAtomicLongSet, (long)c_refdb);
+    (*env)->CallVoidMethod(env, outRefdb, jniConstants->midAtomicLongSet, (jlong)c_refdb);
     return e;
 }
 
@@ -367,7 +367,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniIndex)(JNIEnv *env, jclass ob
 {
     git_index *c_index = 0;
     int e = git_repository_index(&c_index, (git_repository *)repoPtr);
-    (*env)->CallVoidMethod(env, outIndex, jniConstants->midAtomicLongSet, (long)c_index);
+    (*env)->CallVoidMethod(env, outIndex, jniConstants->midAtomicLongSet, (jlong)c_index);
     return e;
 }
 

--- a/src/main/c/git24j/j_repository.c
+++ b/src/main/c/git24j/j_repository.c
@@ -161,8 +161,8 @@ typedef struct
     jstring originUrl;
 } init_options_jobjects;
 
-/** 
- * populate git_repository_init_options with values from java. 
+/**
+ * populate git_repository_init_options with values from java.
  * NOTE: this may allocate char * data that needs to be free-ed separtely.
  */
 void init_options_copy_from_java(JNIEnv *env, jobject initOpts, git_repository_init_options *c_init_opts)
@@ -514,7 +514,7 @@ JNIEXPORT jstring JNICALL J_MAKE_METHOD(Repository_jniGetNamespace)(JNIEnv *env,
 }
 
 /** int git_repository_is_shallow(git_repository *repo); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniIsShadow)(JNIEnv *env, jclass obj, jlong repoPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniIsShallow)(JNIEnv *env, jclass obj, jlong repoPtr)
 {
     return git_repository_is_shallow((git_repository *)repoPtr);
 }

--- a/src/main/c/git24j/j_repository.h
+++ b/src/main/c/git24j/j_repository.h
@@ -133,7 +133,7 @@ extern "C"
     JNIEXPORT jstring JNICALL J_MAKE_METHOD(Repository_jniGetNamespace)(JNIEnv *env, jclass obj, jlong repoPtr);
 
     /** int git_repository_is_shallow(git_repository *repo); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniIsShadow)(JNIEnv *env, jclass obj, jlong repoPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniIsShallow)(JNIEnv *env, jclass obj, jlong repoPtr);
 
     /** int git_repository_ident(const char **name, const char **email, const git_repository *repo); */
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Repository_jniIdent)(JNIEnv *env, jclass obj, jobject identity, jlong repoPtr);

--- a/src/main/c/git24j/j_revert.c
+++ b/src/main/c/git24j/j_revert.c
@@ -13,7 +13,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Revert_jniCommit)(JNIEnv *env, jclass obj, 
 {
     git_index *c_out;
     int r = git_revert_commit(&c_out, (git_repository *)repoPtr, (git_commit *)revertCommitPtr, (git_commit *)ourCommitPtr, mainline, (git_merge_options *)mergeOptionsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_index_free(c_out); */
     return r;
 }
@@ -29,7 +29,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Revert_jniOptionsNew)(JNIEnv *env, jclass o
 {
     git_revert_options *opts = (git_revert_options *)malloc(sizeof(git_revert_options));
     int r = git_revert_options_init(opts, version);
-    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 

--- a/src/main/c/git24j/j_revparse.c
+++ b/src/main/c/git24j/j_revparse.c
@@ -12,14 +12,14 @@ void j_save_revspec_c_value(JNIEnv *env, git_revspec *rev_spec, jobject revSpec)
     assert(clz && "Could not find Revspec class from given revspec object");
     if (rev_spec->from)
     {
-        j_call_setter_long(env, clz, revSpec, "setFrom", (long)(rev_spec->from));
+        j_call_setter_long(env, clz, revSpec, "setFrom", (jlong)(rev_spec->from));
     }
 
     if (rev_spec->to)
     {
-        j_call_setter_long(env, clz, revSpec, "setTo", (long)(rev_spec->to));
+        j_call_setter_long(env, clz, revSpec, "setTo", (jlong)(rev_spec->to));
     }
-    j_call_setter_int(env, clz, revSpec, "setFlags", (long)(rev_spec->flags));
+    j_call_setter_int(env, clz, revSpec, "setFlags", (jlong)(rev_spec->flags));
     (*env)->DeleteLocalRef(env, clz);
 }
 
@@ -38,7 +38,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Revparse_jniSingle)(JNIEnv *env, jclass obj
     git_object *c_out = 0;
     char *c_spec = j_copy_of_jstring(env, spec, false);
     int error = git_revparse_single(&c_out, (git_repository *)repoPtr, c_spec);
-    (*env)->CallVoidMethod(env, outObj, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outObj, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_spec);
     return error;
 }
@@ -49,8 +49,8 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Revparse_jniExt)(JNIEnv *env, jclass obj, j
     git_reference *c_out_ref = 0;
     char *c_spec = j_copy_of_jstring(env, spec, false);
     int error = git_revparse_ext(&c_out_obj, &c_out_ref, (git_repository *)repoPtr, c_spec);
-    (*env)->CallVoidMethod(env, outObj, jniConstants->midAtomicLongSet, (long)c_out_obj);
-    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (long)c_out_ref);
+    (*env)->CallVoidMethod(env, outObj, jniConstants->midAtomicLongSet, (jlong)c_out_obj);
+    (*env)->CallVoidMethod(env, outRef, jniConstants->midAtomicLongSet, (jlong)c_out_ref);
     free(c_spec);
     return error;
 }

--- a/src/main/c/git24j/j_revwalk.c
+++ b/src/main/c/git24j/j_revwalk.c
@@ -41,7 +41,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Revwalk_jniAddHideCb)(JNIEnv *env, jclass o
     j_cb_payload *payload = (j_cb_payload *)malloc(sizeof(j_cb_payload));
     j_cb_payload_init(env, payload, hideCb, "([B)I");
     int e = git_revwalk_add_hide_cb((git_revwalk *)walkPtr, j_git_revwalk_hide_cb, payload);
-    (*env)->CallVoidMethod(env, outPayload, jniConstants->midAtomicLongSet, (long)payload);
+    (*env)->CallVoidMethod(env, outPayload, jniConstants->midAtomicLongSet, (jlong)payload);
     return e;
 }
 
@@ -94,7 +94,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Revwalk_jniNew)(JNIEnv *env, jclass obj, jo
 {
     git_revwalk *c_out = 0;
     int r = git_revwalk_new(&c_out, (git_repository *)repoPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 

--- a/src/main/c/git24j/j_signature.c
+++ b/src/main/c/git24j/j_signature.c
@@ -16,7 +16,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Signature_jniNew)(JNIEnv *env, jclass obj, 
     char *c_name = j_copy_of_jstring(env, name, true);
     char *c_email = j_copy_of_jstring(env, email, true);
     int r = git_signature_new(&c_out, c_name, c_email, time, offset);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_name);
     free(c_email);
     return r;
@@ -30,7 +30,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Signature_jniNow)(JNIEnv *env, jclass obj, 
     char *c_email = j_copy_of_jstring(env, email, true);
 
     int r = git_signature_now(&c_out, c_name, c_email);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_name);
     free(c_email);
     return r;
@@ -41,7 +41,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Signature_jniDefault)(JNIEnv *env, jclass o
 {
     git_signature *c_out = 0;
     int r = git_signature_default(&c_out, (git_repository *)repoPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -51,7 +51,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Signature_jniFromBuffer)(JNIEnv *env, jclas
     git_signature *c_out = 0;
     char *c_buf = j_copy_of_jstring(env, buf, true);
     int r = git_signature_from_buffer(&c_out, c_buf);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_buf);
     return r;
 }
@@ -61,7 +61,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Signature_jniDup)(JNIEnv *env, jclass obj, 
 {
     git_signature *c_dest = 0;
     int r = git_signature_dup(&c_dest, (git_signature *)sigPtr);
-    (*env)->CallVoidMethod(env, dest, jniConstants->midAtomicLongSet, (long)c_dest);
+    (*env)->CallVoidMethod(env, dest, jniConstants->midAtomicLongSet, (jlong)c_dest);
     return r;
 }
 

--- a/src/main/c/git24j/j_stash.c
+++ b/src/main/c/git24j/j_stash.c
@@ -82,7 +82,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Stash_jniPop)(JNIEnv *env, jclass obj, jlon
 
 /** -------- git_stash_apply_options ---------- */
 /** git_stash_apply_options */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Stash_jniApplyFlagsNew)(JNIEnv *env, jclass obj, jobject outPtr, jint version)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Stash_jniApplyOptionsNew)(JNIEnv *env, jclass obj, jobject outPtr, jint version)
 {
     git_stash_apply_options *opts = (git_stash_apply_options *)malloc(sizeof(git_stash_apply_options));
     opts->progress_payload = NULL;

--- a/src/main/c/git24j/j_stash.c
+++ b/src/main/c/git24j/j_stash.c
@@ -24,7 +24,7 @@ int j_git_stash_cb(size_t index, const char *message, const git_oid *stash_id, v
     JNIEnv *env = getEnv();
     jstring jMessage = (*env)->NewStringUTF(env, message);
     jbyteArray stashIdBytes = j_git_oid_to_bytearray(env, stash_id);
-    int r = (*env)->CallIntMethod(env, j_payload->callback, j_payload->mid, (int)index, jMessage, stashIdBytes);
+    int r = (*env)->CallIntMethod(env, j_payload->callback, j_payload->mid, (jint)index, jMessage, stashIdBytes);
     (*env)->DeleteLocalRef(env, jMessage);
     (*env)->DeleteLocalRef(env, stashIdBytes);
     return r;
@@ -87,7 +87,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Stash_jniApplyFlagsNew)(JNIEnv *env, jclass
     git_stash_apply_options *opts = (git_stash_apply_options *)malloc(sizeof(git_stash_apply_options));
     opts->progress_payload = NULL;
     int e = git_stash_apply_options_init(opts, version);
-    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)opts);
     return e;
 }
 

--- a/src/main/c/git24j/j_status.c
+++ b/src/main/c/git24j/j_status.c
@@ -22,7 +22,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Status_jniOptionsNew)(JNIEnv *env, jclass o
 {
     git_status_options *out = (git_status_options *)malloc(sizeof(git_status_options));
     int r = git_status_init_options(out, version);
-    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (long)out);
+    (*env)->CallVoidMethod(env, outOpts, jniConstants->midAtomicLongSet, (jlong)out);
     return r;
 }
 
@@ -42,7 +42,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Status_jniListNew)(JNIEnv *env, jclass obj,
 {
     git_status_list *c_out = 0;
     int r = git_status_list_new(&c_out, (git_repository *)repoPtr, (git_status_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_status_list_free(c_out); */
     return r;
 }

--- a/src/main/c/git24j/j_submodule.c
+++ b/src/main/c/git24j/j_submodule.c
@@ -258,9 +258,9 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdate)(JNIEnv *env, jclass ob
 }
 
 /** int git_submodule_update_init_options(git_submodule_update_options *opts, unsigned int version); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdateInitOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jint version)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdateInitOptions)(JNIEnv *env, jclass obj, jlong updateOptionsPtr, jint version)
 {
-    int r = git_submodule_update_init_options((git_submodule_update_options *)optsPtr, version);
+    int r = git_submodule_update_init_options((git_submodule_update_options *)updateOptionsPtr, version);
     return r;
 }
 

--- a/src/main/c/git24j/j_submodule.c
+++ b/src/main/c/git24j/j_submodule.c
@@ -313,11 +313,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdateStrategy)(JNIEnv *env, j
 JNIEXPORT jstring JNICALL J_MAKE_METHOD(Submodule_jniUrl)(JNIEnv *env, jclass obj, jlong submodulePtr)
 {
     const char *r = git_submodule_url((git_submodule *)submodulePtr);
-    if(!r){ // r is NULL (0)
-        return NULL;
-    }else {
-        return (*env)->NewStringUTF(env, r);
-    }
+    return r ? (*env)->NewStringUTF(env, r) : NULL;
 }
 
 /** const git_oid * git_submodule_wd_id(git_submodule *submodule); */

--- a/src/main/c/git24j/j_submodule.c
+++ b/src/main/c/git24j/j_submodule.c
@@ -43,7 +43,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniAddSetup)(JNIEnv *env, jclass 
     char *c_url = j_copy_of_jstring(env, url, true);
     char *c_path = j_copy_of_jstring(env, path, true);
     int r = git_submodule_add_setup(&c_out, (git_repository *)repoPtr, c_url, c_path, use_gitlink);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_url);
     free(c_path);
     return r;
@@ -119,7 +119,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniLookup)(JNIEnv *env, jclass ob
     git_submodule *c_out = 0;
     char *c_name = j_copy_of_jstring(env, name, true);
     int r = git_submodule_lookup(&c_out, (git_repository *)repoPtr, c_name);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_name);
     return r;
 }
@@ -137,7 +137,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniOpen)(JNIEnv *env, jclass obj,
 {
     git_repository *c_repo = 0;
     int r = git_submodule_open(&c_repo, (git_submodule *)submodulePtr);
-    (*env)->CallVoidMethod(env, repo, jniConstants->midAtomicLongSet, (long)c_repo);
+    (*env)->CallVoidMethod(env, repo, jniConstants->midAtomicLongSet, (jlong)c_repo);
     return r;
 }
 
@@ -167,7 +167,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniRepoInit)(JNIEnv *env, jclass 
 {
     git_repository *c_out = 0;
     int r = git_submodule_repo_init(&c_out, (git_submodule *)smPtr, use_gitlink);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 
@@ -268,7 +268,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdateOptionsNew)(JNIEnv *env,
 {
     git_submodule_update_options *opts = (git_submodule_update_options *)malloc(sizeof(git_submodule_update_options));
     int r = git_submodule_update_init_options(opts, version);
-    (*env)->CallVoidMethod(env, outOpt, jniConstants->midAtomicLongSet, (long)opts);
+    (*env)->CallVoidMethod(env, outOpt, jniConstants->midAtomicLongSet, (jlong)opts);
     return r;
 }
 /** unsigned int version*/
@@ -328,6 +328,6 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniClone)(JNIEnv *env, jclass obj
 {
     git_repository *c_out;
     int r = git_submodule_clone(&c_out, (git_submodule *)submodulePtr, (git_submodule_update_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }

--- a/src/main/c/git24j/j_submodule.c
+++ b/src/main/c/git24j/j_submodule.c
@@ -313,7 +313,11 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdateStrategy)(JNIEnv *env, j
 JNIEXPORT jstring JNICALL J_MAKE_METHOD(Submodule_jniUrl)(JNIEnv *env, jclass obj, jlong submodulePtr)
 {
     const char *r = git_submodule_url((git_submodule *)submodulePtr);
-    return (*env)->NewStringUTF(env, r);
+    if(!r){ // r is NULL (0)
+        return NULL;
+    }else {
+        return (*env)->NewStringUTF(env, r);
+    }
 }
 
 /** const git_oid * git_submodule_wd_id(git_submodule *submodule); */

--- a/src/main/c/git24j/j_submodule.h
+++ b/src/main/c/git24j/j_submodule.h
@@ -99,7 +99,7 @@ extern "C"
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdate)(JNIEnv *env, jclass obj, jlong submodulePtr, jint init, jlong optionsPtr);
 
     /** int git_submodule_update_init_options(git_submodule_update_options *opts, unsigned int version); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdateInitOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jint version);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdateInitOptions)(JNIEnv *env, jclass obj, jlong updateOptionsPtr, jint version);
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdateOptionsNew)(JNIEnv *env, jclass obj, jobject outOpt, jint version);
     /** git_checkout_options *checkout_opts*/
     JNIEXPORT jlong JNICALL J_MAKE_METHOD(Submodule_jniUpdateOptionsGetCheckoutOpts)(JNIEnv *env, jclass obj, jlong updateOptionsPtr);

--- a/src/main/c/git24j/j_tag.c
+++ b/src/main/c/git24j/j_tag.c
@@ -42,7 +42,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Tag_jniTarget)(JNIEnv *env, jclass obj, job
 {
     git_object *target_out = 0;
     int e = git_tag_target(&target_out, (git_tag *)tagPtr);
-    (*env)->CallVoidMethod(env, outTargetPtr, jniConstants->midAtomicLongSet, (long)target_out);
+    (*env)->CallVoidMethod(env, outTargetPtr, jniConstants->midAtomicLongSet, (jlong)target_out);
     return e;
 }
 /** const git_oid * git_tag_target_id(const git_tag *tag); */
@@ -175,7 +175,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Tag_jniPeel)(JNIEnv *env, jclass obj, jobje
 {
     git_object *tag_target_out = 0;
     int e = git_tag_peel(&tag_target_out, (const git_tag *)tagPtr);
-    (*env)->CallVoidMethod(env, outTarget, jniConstants->midAtomicLongSet, (long)tag_target_out);
+    (*env)->CallVoidMethod(env, outTarget, jniConstants->midAtomicLongSet, (jlong)tag_target_out);
     return e;
 }
 
@@ -184,6 +184,6 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Tag_jniDup)(JNIEnv *env, jclass obj, jobjec
 {
     git_tag *c_out = 0;
     int e = git_tag_dup(&c_out, (git_tag *)sourcePtr);
-    (*env)->CallVoidMethod(env, outTag, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, outTag, jniConstants->midAtomicLongSet, (jlong)c_out);
     return e;
 }

--- a/src/main/c/git24j/j_transaction.c
+++ b/src/main/c/git24j/j_transaction.c
@@ -14,7 +14,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Transaction_jniNew)(JNIEnv *env, jclass obj
 {
     git_transaction *c_out = 0;
     int r = git_transaction_new(&c_out, (git_repository *)repoPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_transaction_free(c_out); */
     return r;
 }

--- a/src/main/c/git24j/j_tree.c
+++ b/src/main/c/git24j/j_tree.c
@@ -253,9 +253,9 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Tree_jniBuilderNew)(JNIEnv *env, jclass obj
 }
 
 /** int git_treebuilder_clear(git_tree_builder *bld); */
-JNIEXPORT void JNICALL J_MAKE_METHOD(Tree_jniBuilderClear)(JNIEnv *env, jclass obj, jlong bldPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Tree_jniBuilderClear)(JNIEnv *env, jclass obj, jlong bldPtr)
 {
-    git_treebuilder_clear((git_treebuilder *)bldPtr);
+    return git_treebuilder_clear((git_treebuilder *)bldPtr);
 }
 
 /** size_t git_treebuilder_entrycount(git_tree_builder *bld); */

--- a/src/main/c/git24j/j_tree.c
+++ b/src/main/c/git24j/j_tree.c
@@ -100,7 +100,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Tree_jniEntryBypath)(JNIEnv *env, jclass ob
     git_tree_entry *c_out = 0;
     char *c_path = j_copy_of_jstring(env, path, true);
     int r = git_tree_entry_bypath(&c_out, (git_tree *)rootPtr, c_path);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_tree_entry_free(c_out); */
     free(c_path);
     return r;
@@ -111,7 +111,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Tree_jniEntryDup)(JNIEnv *env, jclass obj, 
 {
     git_tree_entry *c_dest = 0;
     int r = git_tree_entry_dup(&c_dest, (git_tree_entry *)sourcePtr);
-    (*env)->CallVoidMethod(env, dest, jniConstants->midAtomicLongSet, (long)c_dest);
+    (*env)->CallVoidMethod(env, dest, jniConstants->midAtomicLongSet, (jlong)c_dest);
     /* git_tree_entry_free(c_dest); */
     return r;
 }
@@ -169,7 +169,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Tree_jniEntryToObject)(JNIEnv *env, jclass 
 {
     git_object *c_object_out = 0;
     int r = git_tree_entry_to_object(&c_object_out, (git_repository *)repoPtr, (git_tree_entry *)entryPtr);
-    (*env)->CallVoidMethod(env, objectOut, jniConstants->midAtomicLongSet, (long)c_object_out);
+    (*env)->CallVoidMethod(env, objectOut, jniConstants->midAtomicLongSet, (jlong)c_object_out);
     /* git_object_free(c_object_out); */
     return r;
 }
@@ -179,7 +179,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Tree_jniDup)(JNIEnv *env, jclass obj, jobje
 {
     git_tree *c_out = 0;
     int r = git_tree_dup(&c_out, (git_tree *)sourcePtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_tree_free(c_out); */
     return r;
 }
@@ -247,7 +247,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Tree_jniBuilderNew)(JNIEnv *env, jclass obj
 {
     git_treebuilder *c_out = 0;
     int r = git_treebuilder_new(&c_out, (git_repository *)repoPtr, (git_tree *)sourcePtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     /* git_treebuilder_free(c_out); */
     return r;
 }

--- a/src/main/c/git24j/j_tree.h
+++ b/src/main/c/git24j/j_tree.h
@@ -82,8 +82,8 @@ extern "C"
     /** int git_treebuilder_new(git_tree_builder **out, git_repository *repo, const git_tree *source); */
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Tree_jniBuilderNew)(JNIEnv *env, jclass obj, jobject out, jlong repoPtr, jlong sourcePtr);
 
-    /** void git_treebuilder_clear(git_tree_builder *bld); */
-    JNIEXPORT void JNICALL J_MAKE_METHOD(Tree_jniBuilderClear)(JNIEnv *env, jclass obj, jlong bldPtr);
+    /** int git_treebuilder_clear(git_tree_builder *bld); */
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Tree_jniBuilderClear)(JNIEnv *env, jclass obj, jlong bldPtr);
 
     /** size_t git_treebuilder_entrycount(git_tree_builder *bld); */
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Tree_jniBuilderEntrycount)(JNIEnv *env, jclass obj, jlong bldPtr);

--- a/src/main/c/git24j/j_util.c
+++ b/src/main/c/git24j/j_util.c
@@ -20,7 +20,7 @@ void j_save_c_pointer(JNIEnv *env, void *ptr, jobject object, const char *setter
         j_throw_jni_error(env, "cannot find setter to save native pointer.");
     }
 
-    (*env)->CallVoidMethod(env, object, method, (long)ptr);
+    (*env)->CallVoidMethod(env, object, method, (jlong)ptr);
     (*env)->DeleteLocalRef(env, clz);
 }
 

--- a/src/main/c/git24j/j_worktree.c
+++ b/src/main/c/git24j/j_worktree.c
@@ -13,7 +13,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Worktree_jniAdd)(JNIEnv *env, jclass obj, j
     char *c_name = j_copy_of_jstring(env, name, true);
     char *c_path = j_copy_of_jstring(env, path, true);
     int r = git_worktree_add(&c_out, (git_repository *)repoPtr, c_name, c_path, (git_worktree_add_options *)optsPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_name);
     free(c_path);
     return r;
@@ -75,7 +75,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Worktree_jniLookup)(JNIEnv *env, jclass obj
     git_worktree *c_out = 0;
     char *c_name = j_copy_of_jstring(env, name, true);
     int r = git_worktree_lookup(&c_out, (git_repository *)repoPtr, c_name);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     free(c_name);
     return r;
 }
@@ -92,7 +92,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Worktree_jniOpenFromRepository)(JNIEnv *env
 {
     git_worktree *c_out = 0;
     int r = git_worktree_open_from_repository(&c_out, (git_repository *)repoPtr);
-    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (long)c_out);
+    (*env)->CallVoidMethod(env, out, jniConstants->midAtomicLongSet, (jlong)c_out);
     return r;
 }
 

--- a/src/main/c/git24j/j_writestream.c
+++ b/src/main/c/git24j/j_writestream.c
@@ -3,7 +3,7 @@
 #include "j_util.h"
 
 /** int (*)(git_writestream *, const char *, size_t); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(WriteStream_jniWrite)(JNIEnv *env, jclass obj, long wsPtr, jbyteArray content)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(WriteStream_jniWrite)(JNIEnv *env, jclass obj, jlong wsPtr, jbyteArray content)
 {
     int out_len;
     unsigned char *c_bytes = j_unsigned_chars_from_java(env, content, &out_len);
@@ -13,13 +13,13 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(WriteStream_jniWrite)(JNIEnv *env, jclass o
     return e;
 }
 
-JNIEXPORT void JNICALL J_MAKE_METHOD(WriteStream_jniFree)(JNIEnv *env, jclass obj, long wsPtr)
+JNIEXPORT void JNICALL J_MAKE_METHOD(WriteStream_jniFree)(JNIEnv *env, jclass obj, jlong wsPtr)
 {
     git_writestream *c_ws = (git_writestream *)wsPtr;
     c_ws->free(c_ws);
 }
 
-JNIEXPORT jint JNICALL J_MAKE_METHOD(WriteStream_jniClose)(JNIEnv *env, jclass obj, long wsPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(WriteStream_jniClose)(JNIEnv *env, jclass obj, jlong wsPtr)
 {
     git_writestream *c_ws = (git_writestream *)wsPtr;
     return c_ws->close(c_ws);

--- a/src/main/c/git24j/j_writestream.h
+++ b/src/main/c/git24j/j_writestream.h
@@ -9,9 +9,9 @@ extern "C"
 {
 #endif
 
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(WriteStream_jniWrite)(JNIEnv *env, jclass obj, long wsPtr, jbyteArray content);
-    JNIEXPORT void JNICALL J_MAKE_METHOD(WriteStream_jniFree)(JNIEnv *env, jclass obj, long wsPtr);
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(WriteStream_jniClose)(JNIEnv *env, jclass obj, long wsPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(WriteStream_jniWrite)(JNIEnv *env, jclass obj, jlong wsPtr, jbyteArray content);
+    JNIEXPORT void JNICALL J_MAKE_METHOD(WriteStream_jniFree)(JNIEnv *env, jclass obj, jlong wsPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(WriteStream_jniClose)(JNIEnv *env, jclass obj, jlong wsPtr);
 
 #ifdef __cplusplus
 }

--- a/src/main/java/com/github/git24j/core/AnnotatedCommit.java
+++ b/src/main/java/com/github/git24j/core/AnnotatedCommit.java
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * that data is known.
  */
 public class AnnotatedCommit extends CAutoReleasable {
-    static native String jniFree(long acPtr);
+    static native void jniFree(long acPtr);
 
     static native int jniFromFetchHead(
             AtomicLong outAc, long repoPtr, String branchName, String remoteUrl, Oid oid);

--- a/src/main/java/com/github/git24j/core/Apply.java
+++ b/src/main/java/com/github/git24j/core/Apply.java
@@ -60,7 +60,7 @@ public class Apply {
      * @param location the location to apply (workdir, index or both)
      * @param options the options for the apply (or null for defaults)
      */
-    public void apply(
+    public static void apply(
             @Nonnull Repository repo,
             @Nonnull Diff diff,
             @Nonnull LocationT location,
@@ -93,17 +93,21 @@ public class Apply {
     }
 
     public enum LocationT implements IBitEnum {
+        /**
+         * Apply the patch to the workdir, leaving the index untouched.
+         * This is the equivalent of `git apply` with no location argument.
+         */
         WORKDIR(0),
 
         /**
-         * Apply the patch to the index, leaving the working directory untouched. This is the
-         * equivalent of `git apply --cached`.
+         * Apply the patch to the index, leaving the working directory
+         * untouched.  This is the equivalent of `git apply --cached`.
          */
         INDEX(1),
 
         /**
-         * Apply the patch to both the working directory and the index. This is the equivalent of
-         * `git apply --index`.
+         * Apply the patch to both the working directory and the index.
+         * This is the equivalent of `git apply --index`.
          */
         BOTH(2),
         ;

--- a/src/main/java/com/github/git24j/core/Blame.java
+++ b/src/main/java/com/github/git24j/core/Blame.java
@@ -57,10 +57,8 @@ public class Blame extends CAutoReleasable {
     /** size_t orig_start_line_number */
     static native int jniHunkGetOrigStartLineNumber(long hunkPtr);
 
-    /** int git_blame_init_options(git_blame_options *opts, unsigned int version); */
-    static native int jniInitOptions(long opts, int version);
-
-    static native void jniOptionsNew(AtomicLong outPtr, int version);
+    // return is the errcode, not 0 means err
+    static native int jniOptionsNew(AtomicLong outPtr, int version);
 
     protected Blame(boolean isWeak, long rawPtr) {
         super(isWeak, rawPtr);
@@ -169,7 +167,11 @@ public class Blame extends CAutoReleasable {
          * names and email addresses. The mailmap will be read from the working directory, or HEAD
          * in a bare repository.
          */
-        USE_MAILMAP(1 << 5);
+        USE_MAILMAP(1 << 5),
+
+        /** Ignore whitespace differences */
+        IGNORE_WHITESPACE(1 << 6);
+
         private final int _bit;
 
         FlagT(int bit) {
@@ -189,9 +191,9 @@ public class Blame extends CAutoReleasable {
             super(isWeak, rawPtr);
         }
 
-        public static Options init(int version) {
+        public static Options create(int version) {
             Options out = new Options(false, 0);
-            jniOptionsNew(out._rawPtr, version);
+            Error.throwIfNeeded(jniOptionsNew(out._rawPtr, version));
             return out;
         }
 

--- a/src/main/java/com/github/git24j/core/Blob.java
+++ b/src/main/java/com/github/git24j/core/Blob.java
@@ -144,7 +144,7 @@ public class Blob extends GitObject {
      * instead.
      *
      * @param repo git repo
-     * @param oid sha of the blob to search.
+     * @param shortId oid sha of the blob to search.
      * @return found blob or null
      * @throws GitException git error
      */

--- a/src/main/java/com/github/git24j/core/Branch.java
+++ b/src/main/java/com/github/git24j/core/Branch.java
@@ -360,7 +360,7 @@ public class Branch {
 
         @Override
         protected void finalize() throws Throwable {
-            if (_ptr.get() > 0) {
+            if (_ptr.get() != 0) {
                 jniIteratorFree(_ptr.get());
             }
             super.finalize();

--- a/src/main/java/com/github/git24j/core/Branch.java
+++ b/src/main/java/com/github/git24j/core/Branch.java
@@ -326,7 +326,7 @@ public class Branch {
             _bit = bit;
         }
 
-        static BranchType valueOf(int iVal) {
+        public static BranchType valueOf(int iVal) {
             return IBitEnum.valueOf(iVal, BranchType.class, INVALID);
         }
 

--- a/src/main/java/com/github/git24j/core/Branch.java
+++ b/src/main/java/com/github/git24j/core/Branch.java
@@ -68,7 +68,7 @@ public class Branch {
                         repo.getRawPointer(),
                         branchName,
                         target.getRawPointer(),
-                        force ? 0 : 1));
+                        force ? 1 : 0));
         return new Reference(false, outRef.get());
     }
 
@@ -130,7 +130,7 @@ public class Branch {
     public static Reference move(Reference branch, String branchName, boolean force) {
         Reference outRef = new Reference(true, 0);
         Error.throwIfNeeded(
-                jniMove(outRef._rawPtr, branch.getRawPointer(), branchName, force ? 0 : 1));
+                jniMove(outRef._rawPtr, branch.getRawPointer(), branchName, force ? 1 : 0));
         return outRef;
     }
 

--- a/src/main/java/com/github/git24j/core/Branch.java
+++ b/src/main/java/com/github/git24j/core/Branch.java
@@ -234,7 +234,7 @@ public class Branch {
             return null;
         }
         Error.throwIfNeeded(e);
-        return outBuf.getPtr();
+        return outBuf.toString();
     }
 
     /**
@@ -291,7 +291,7 @@ public class Branch {
             return null;
         }
         Error.throwIfNeeded(e);
-        return outBuf.getPtr();
+        return outBuf.toString();
     }
 
     /**
@@ -311,7 +311,7 @@ public class Branch {
         if (e == GitException.ErrorCode.ENOTFOUND.getCode()) {
             return null;
         }
-        return outBuf.getPtr();
+        return outBuf.toString();
     }
 
     public enum BranchType implements IBitEnum {

--- a/src/main/java/com/github/git24j/core/Buf.java
+++ b/src/main/java/com/github/git24j/core/Buf.java
@@ -1,11 +1,27 @@
 package com.github.git24j.core;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 public class Buf {
+    /*
+    if jni.NewStringUTF() just simple make a pointer point to char*, I think this will work well, else idk.
+
+    actually this is java String from libgit2's buf->ptr, so this is not identical libgit2's buf->ptr,
+     and idk this is a good c string copy or not,
+     the source codes is simple use jni.NewStringUTF() get java string from c string,
+     the point is "no length of c string when use jni.NewStringUTF()",
+     so idk if no '\0' of end, this will work as expected or not.
+
+     relate c code:
+     j_mappers.c `void j_git_buf_to_java(JNIEnv *env, git_buf *c_buf, jobject buf)`
+     j_mappers.c `void j_call_setter_string_c(JNIEnv *env, jclass clz, jobject obj, const char *method, const char *val)`
+
+     */
     private String ptr;
+
     private int reserved;
-    private int size;
+    private int size;  // length of c char ( java byte) not java char
 
     /** Get internal buffer, generally only the substr up to size is meaningful. */
     String getPtr() {
@@ -34,9 +50,18 @@ public class Buf {
 
     public Optional<String> getString() {
         if (ptr == null || size == 0) {
-            return Optional.empty();
+            return Optional.empty();  // value of empty Optional is null
         }
-        return Optional.of(ptr.substring(0, size));
+
+        String ret = ptr;
+
+        byte[] src = ptr.getBytes(StandardCharsets.UTF_8);
+        //the String maybe over size of c string, so check size, if oversize, cut it
+        if(src.length > size) {
+            ret = new String(src, 0, size, StandardCharsets.UTF_8);
+        }
+
+        return Optional.of(ret);
     }
 
     @Override

--- a/src/main/java/com/github/git24j/core/CAutoCloseable.java
+++ b/src/main/java/com/github/git24j/core/CAutoCloseable.java
@@ -37,7 +37,7 @@ public abstract class CAutoCloseable implements AutoCloseable {
 
     @Override
     public void close() {
-        if (_rawPtr.get() > 0) {
+        if (_rawPtr.get() != 0) {
             releaseOnce(_rawPtr.getAndSet(0));
         }
     }

--- a/src/main/java/com/github/git24j/core/CAutoReleasable.java
+++ b/src/main/java/com/github/git24j/core/CAutoReleasable.java
@@ -27,7 +27,7 @@ public abstract class CAutoReleasable {
 
     @Override
     protected void finalize() throws Throwable {
-        if (!_isWeak && _rawPtr.get() > 0) {
+        if (!_isWeak && _rawPtr.get() != 0) {
             freeOnce(_rawPtr.getAndSet(0));
         }
         super.finalize();

--- a/src/main/java/com/github/git24j/core/Checkout.java
+++ b/src/main/java/com/github/git24j/core/Checkout.java
@@ -216,11 +216,9 @@ public class Checkout {
     }
 
     public enum StrategyT implements IBitEnum {
-        /** default is a dry run, no actual updates */
-        NONE(0),
-
         /** Allow safe updates that cannot overwrite uncommitted data */
-        SAFE(1 << 0),
+        // updated from 1 to 0, since libgit2 1.9.0
+        SAFE(0),
 
         /** Allow all updates to force working directory to look like index */
         FORCE(1 << 1),
@@ -276,10 +274,39 @@ public class Checkout {
 
         /** Normally checkout writes the index upon completion; this prevents that. */
         DONT_WRITE_INDEX(1 << 23),
+
+
+        /**
+         * Perform a "dry run", reporting what _would_ be done but
+         * without actually making changes in the working directory
+         * or the index.
+         */
+        DRY_RUN(1 << 24),
+
+        /** Include common ancestor data in zdiff3 format for conflicts */
+        CONFLICT_STYLE_ZDIFF3(1 << 25),
+
+        /**
+         * Do not do a checkout and do not fire callbacks; this is primarily
+         * useful only for internal functions that will perform the
+         * checkout themselves but need to pass checkout options into
+         * another function, for example, `git_clone`.
+        */
+        NONE(1 << 30),
+
+
+        /*
+         * THE FOLLOWING OPTIONS ARE NOT YET IMPLEMENTED
+         */
+
+
         /** Recursively checkout submodules with same options (NOT IMPLEMENTED) */
         UPDATE_SUBMODULES(1 << 16),
+
         /** Recursively checkout submodules if HEAD moved in super repo (NOT IMPLEMENTED) */
         UPDATE_SUBMODULES_IF_CHANGED(1 << 17);
+
+
         private final int _bit;
 
         StrategyT(int bit) {

--- a/src/main/java/com/github/git24j/core/Checkout.java
+++ b/src/main/java/com/github/git24j/core/Checkout.java
@@ -314,18 +314,18 @@ public class Checkout {
 
     @FunctionalInterface
     public interface NotifyCb {
-        int accept(
+        public int accept(
                 NotifyT why, String path, Diff.File baseline, Diff.File target, Diff.File workdir);
     }
 
     @FunctionalInterface
     public interface ProgressCb {
-        void accept(@CheckForNull String path, int completedSteps, int totalSteps);
+        public void accept(@CheckForNull String path, int completedSteps, int totalSteps);
     }
 
     @FunctionalInterface
     public interface PerfdataCb {
-        void accept(int mkdirCalls, int statCalls, int chmodCalls);
+        public void accept(int mkdirCalls, int statCalls, int chmodCalls);
     }
 
     /**

--- a/src/main/java/com/github/git24j/core/Checkout.java
+++ b/src/main/java/com/github/git24j/core/Checkout.java
@@ -314,18 +314,18 @@ public class Checkout {
 
     @FunctionalInterface
     public interface NotifyCb {
-        public int accept(
+        int accept(
                 NotifyT why, String path, Diff.File baseline, Diff.File target, Diff.File workdir);
     }
 
     @FunctionalInterface
     public interface ProgressCb {
-        public void accept(@CheckForNull String path, int completedSteps, int totalSteps);
+        void accept(@CheckForNull String path, int completedSteps, int totalSteps);
     }
 
     @FunctionalInterface
     public interface PerfdataCb {
-        public void accept(int mkdirCalls, int statCalls, int chmodCalls);
+        void accept(int mkdirCalls, int statCalls, int chmodCalls);
     }
 
     /**

--- a/src/main/java/com/github/git24j/core/Cherrypick.java
+++ b/src/main/java/com/github/git24j/core/Cherrypick.java
@@ -69,7 +69,7 @@ public class Cherrypick {
         return out;
     }
 
-    public void cherrypick(
+    public static void cherrypick(
             @Nonnull Repository repo, @Nonnull Commit commit, @Nullable Options options) {
         int e =
                 jniCherrypick(

--- a/src/main/java/com/github/git24j/core/Cherrypick.java
+++ b/src/main/java/com/github/git24j/core/Cherrypick.java
@@ -30,6 +30,7 @@ public class Cherrypick {
 
     /** unsigned int mainline */
     static native int jniOptionsGetMainline(long optionsPtr);
+    static native void jniOptionsSetMainline(long optionsPtr, int mainline);
     /** git_merge_options merge_opts */
     static native long jniOptionsGetMergeOpts(long optionsPtr);
     /** git_checkout_options checkout_opts */
@@ -105,6 +106,10 @@ public class Cherrypick {
 
         public int getMainline() {
             return jniOptionsGetMainline(getRawPointer());
+        }
+
+        public void setMainline(int mainline) {
+            jniOptionsSetMainline(getRawPointer(), mainline);
         }
 
         public Merge.Options getMergeOpts() {

--- a/src/main/java/com/github/git24j/core/Commit.java
+++ b/src/main/java/com/github/git24j/core/Commit.java
@@ -567,6 +567,6 @@ public class Commit extends GitObject {
 
     @FunctionalInterface
     public interface SigningCb {
-        int accept(String signature, String signatureField, String commitContent);
+        public int accept(String signature, String signatureField, String commitContent);
     }
 }

--- a/src/main/java/com/github/git24j/core/Commit.java
+++ b/src/main/java/com/github/git24j/core/Commit.java
@@ -567,6 +567,6 @@ public class Commit extends GitObject {
 
     @FunctionalInterface
     public interface SigningCb {
-        public int accept(String signature, String signatureField, String commitContent);
+        int accept(String signature, String signatureField, String commitContent);
     }
 }

--- a/src/main/java/com/github/git24j/core/Config.java
+++ b/src/main/java/com/github/git24j/core/Config.java
@@ -799,7 +799,10 @@ public class Config extends CAutoReleasable {
 
         @Override
         protected void freeOnce(long cPtr) {
-            jniEntryFree(cPtr);
+
+            // libgit2 1.9.0 say: "end-users should not try to free that structure"
+            // see: https://github.com/libgit2/libgit2/releases/tag/v1.9.0 , section "Breaking changes", sub section "Configuration entry member removal (ABI breaking change)"
+            // jniEntryFree(cPtr);
         }
 
         public String getName() {

--- a/src/main/java/com/github/git24j/core/Config.java
+++ b/src/main/java/com/github/git24j/core/Config.java
@@ -48,6 +48,22 @@ public class Config extends CAutoReleasable {
     /** const char *value */
     static native String jniEntryGetValue(long entryPtr);
 
+    /**
+     * The type of backend that this entry exists in (eg, "file")
+     *
+     *
+     * @since libgit2 1.8.0
+     * */
+    static native String jniEntryGetBackendType(long entryPtr);
+    /**
+     * The path to the origin of this entry. For config files, this is
+     * the path to the file.
+     *
+     *
+     * @since libgit2 1.8.0
+     */
+    static native String jniEntryGetOriginPath(long entryPtr);
+
     /** int git_config_find_global(git_buf *out); */
     static native int jniFindGlobal(Buf out);
 
@@ -735,8 +751,19 @@ public class Config extends CAutoReleasable {
         /** Repository specific configuration file; $WORK_DIR/.git/config on non-bare repos */
         LOCAL(5),
 
-        /** Application specific configuration file; freely defined by applications */
-        APP(6),
+        /**
+         * Worktree specific configuration file; $GIT_DIR/config.worktree
+
+         @since libgit2 1.8.0
+         */
+        WORKTREE(6),
+
+
+        /** Application specific configuration file; freely defined by applications
+         *
+         * @since libgit2 1.8 change to 7, before is 6
+         * */
+        APP(7),
 
         /**
          * Represents the highest level available config file (i.e. the most specific config file
@@ -789,6 +816,14 @@ public class Config extends CAutoReleasable {
 
         public int getLevel() {
             return jniEntryGetLevel(getRawPointer());
+        }
+
+        public String getBackendType(){
+            return jniEntryGetBackendType(getRawPointer());
+        }
+
+        public String getOriginPath(){
+            return jniEntryGetOriginPath(getRawPointer());
         }
     }
 

--- a/src/main/java/com/github/git24j/core/Cred.java
+++ b/src/main/java/com/github/git24j/core/Cred.java
@@ -8,8 +8,7 @@ public class Cred extends CAutoReleasable {
      * int git_cred_acquire_cb(git_cred **cred, const char *url, const char *username_from_url,
      * unsigned int allowed_types, void *payload);
      */
-    static native int jniAcquireCb(
-            AtomicLong cred, String url, String usernameFromUrl, int allowedTypes);
+//    static native int jniAcquireCb( AtomicLong cred, String url, String usernameFromUrl, int allowedTypes);
 
     /** int git_cred_default_new(git_cred **out); */
     static native int jniDefaultNew(AtomicLong out);
@@ -52,8 +51,7 @@ public class Cred extends CAutoReleasable {
      * int git_cred_userpass(git_cred **cred, const char *url, const char *user_from_url, unsigned
      * int allowed_types, void *payload);
      */
-    static native int jniUserpass(
-            AtomicLong cred, String url, String userFromUrl, int allowedTypes);
+//    static native int jniUserpass( AtomicLong cred, String url, String userFromUrl, int allowedTypes);
 
     /**
      * int git_cred_userpass_plaintext_new(git_cred **out, const char *username, const char

--- a/src/main/java/com/github/git24j/core/Diff.java
+++ b/src/main/java/com/github/git24j/core/Diff.java
@@ -278,7 +278,7 @@ public class Diff extends CAutoReleasable {
     /** int git_diff_patchid_init_options(git_diff_patchid_options *opts, unsigned int version); */
     static native int jniPatchidInitOptions(long opts, int version);
 
-    static native int jniPatchidOptionsFree(long opts);
+    static native void jniPatchidOptionsFree(long opts);
 
     static native int jniPatchidOptionsNew(AtomicLong outOpts, int version);
 

--- a/src/main/java/com/github/git24j/core/Diff.java
+++ b/src/main/java/com/github/git24j/core/Diff.java
@@ -1254,7 +1254,11 @@ public class Diff extends CAutoReleasable {
         NAME_ONLY(4),
         /** < like git diff --name-status */
         NAME_STATUS(5),
+        /**< git diff as used by git patch-id */
+        PATCH_ID(6),
+
         ;
+
         private final int _code;
 
         FormatT(int _code) {

--- a/src/main/java/com/github/git24j/core/Diff.java
+++ b/src/main/java/com/github/git24j/core/Diff.java
@@ -908,9 +908,9 @@ public class Diff extends CAutoReleasable {
      * @throws GitException git errors
      */
     @Nonnull
-    public Diff fromBuffer(@Nonnull String content) {
+    public static Diff fromBuffer(@Nonnull String content) {
         Diff diff = new Diff(false, 0);
-        Error.throwIfNeeded(jniFromBuffer(diff._rawPtr, content, content.length()));
+        Error.throwIfNeeded(jniFromBuffer(diff._rawPtr, content, content.getBytes(StandardCharsets.UTF_8).length));
         return diff;
     }
 

--- a/src/main/java/com/github/git24j/core/Diff.java
+++ b/src/main/java/com/github/git24j/core/Diff.java
@@ -1808,9 +1808,7 @@ public class Diff extends CAutoReleasable {
             int headerLen = getHeaderLen();
             byte[] src = rawHeader.getBytes(StandardCharsets.UTF_8);
             if(src.length > headerLen) {
-                byte[] dest = new byte[headerLen];
-                System.arraycopy(src, 0, dest, 0, headerLen);
-                return new String(dest);
+                return new String(src, 0, headerLen, StandardCharsets.UTF_8);
             }
 
             return rawHeader;
@@ -1968,9 +1966,7 @@ public class Diff extends CAutoReleasable {
             byte[] src = content.getBytes(StandardCharsets.UTF_8);
             // bytes.length < contentLen maybe not happen, because contentLen should be a part of content
             if(src.length > contentLen) {  //if content length bigger than contentLen, create a new sub array
-                byte[] dest = new byte[contentLen];
-                System.arraycopy(src,0,dest,0,contentLen);
-                return new String(dest);
+                return new String(src, 0, contentLen, StandardCharsets.UTF_8);
             }
 
             // if content length equals contentLen, just return it, no more operations required

--- a/src/main/java/com/github/git24j/core/Diff.java
+++ b/src/main/java/com/github/git24j/core/Diff.java
@@ -3,6 +3,7 @@ package com.github.git24j.core;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -1803,7 +1804,16 @@ public class Diff extends CAutoReleasable {
         }
 
         public String getHeader() {
-            return jniHunkGetHeader(getRawPointer());
+            String rawHeader = jniHunkGetHeader(getRawPointer());
+            int headerLen = getHeaderLen();
+            byte[] src = rawHeader.getBytes(StandardCharsets.UTF_8);
+            if(src.length > headerLen) {
+                byte[] dest = new byte[headerLen];
+                System.arraycopy(src, 0, dest, 0, headerLen);
+                return new String(dest);
+            }
+
+            return rawHeader;
         }
     }
 
@@ -1955,17 +1965,17 @@ public class Diff extends CAutoReleasable {
 //            if (content.length() >= contentLen) {
 //                return content.substring(0, contentLen);
 //            }
-            byte[] bytes = content.getBytes();
+            byte[] src = content.getBytes(StandardCharsets.UTF_8);
             // bytes.length < contentLen maybe not happen, because contentLen should be a part of content
-            if(bytes.length > contentLen) {  //if content length bigger than contentLen, create a new sub array
-                byte[] nb = new byte[contentLen];
-                for(int i =0; i<contentLen; i++) {  // fill the sub array
-                    nb[i]=bytes[i];
-                }
-                return new String(nb);
-            }else {  // if content length equals contentLen, just return it, no more operations required
-                return content;
+            if(src.length > contentLen) {  //if content length bigger than contentLen, create a new sub array
+                byte[] dest = new byte[contentLen];
+                System.arraycopy(src,0,dest,0,contentLen);
+                return new String(dest);
             }
+
+            // if content length equals contentLen, just return it, no more operations required
+            return content;
+
         }
     }
 

--- a/src/main/java/com/github/git24j/core/Diff.java
+++ b/src/main/java/com/github/git24j/core/Diff.java
@@ -1950,10 +1950,22 @@ public class Diff extends CAutoReleasable {
         public String getContent() {
             String content = jniLineGetContent(getRawPointer());
             int contentLen = jniLineGetContentLen(getRawPointer());
-            if (content.length() >= contentLen) {
-                return content.substring(0, contentLen);
+            // content.length() is "chars count", not "bytes count"!
+            // so this code is wrong in some cases! sometimes it will give you more lines than you wanted.
+//            if (content.length() >= contentLen) {
+//                return content.substring(0, contentLen);
+//            }
+            byte[] bytes = content.getBytes();
+            // bytes.length < contentLen maybe not happen, because contentLen should be a part of content
+            if(bytes.length > contentLen) {  //if content length bigger than contentLen, create a new sub array
+                byte[] nb = new byte[contentLen];
+                for(int i =0; i<contentLen; i++) {  // fill the sub array
+                    nb[i]=bytes[i];
+                }
+                return new String(nb);
+            }else {  // if content length equals contentLen, just return it, no more operations required
+                return content;
             }
-            return content;
         }
     }
 

--- a/src/main/java/com/github/git24j/core/Diff.java
+++ b/src/main/java/com/github/git24j/core/Diff.java
@@ -240,6 +240,14 @@ public class Diff extends CAutoReleasable {
     /** size_t content_offset */
     static native int jniLineGetContentOffset(long linePtr);
 
+    /**
+     *
+     * @param linePtr line ptr
+     * @return if content len > 0, return byte arr; else return null
+     */
+    @Nullable
+    static native byte[] jniLineGetContentBytes(long linePtr);
+
     /** int new_lineno */
     static native int jniLineGetNewLineno(long linePtr);
 
@@ -1955,7 +1963,27 @@ public class Diff extends CAutoReleasable {
             return jniLineGetContentOffset(getRawPointer());
         }
 
-        public String getContent() {
+        /**
+         * @return if content len > 0, return byte arr, else return null
+         */
+        @Nullable
+        public byte[] getContentBytes(){
+            return jniLineGetContentBytes(getRawPointer());
+        }
+
+        public String getContent(){
+            byte[] bytes = getContentBytes();
+
+            return (bytes!=null) ? new String(bytes, StandardCharsets.UTF_8) : "";
+        }
+
+
+        /**
+         * This has more data copy than getContent(), not recommended to use
+         * @return
+         */
+        @Deprecated
+        public String getContent_Deprecated() {
             String content = jniLineGetContent(getRawPointer());
             int contentLen = jniLineGetContentLen(getRawPointer());
             // content.length() is "chars count", not "bytes count"!

--- a/src/main/java/com/github/git24j/core/Error.java
+++ b/src/main/java/com/github/git24j/core/Error.java
@@ -2,10 +2,20 @@ package com.github.git24j.core;
 
 /** Delegate git_error_* methods. */
 public class Error {
+    /**
+     * deprecated by libgit2 1.8.x
+     */
+    @Deprecated
     static native void jniClear();
 
     static native GitException jniLast();
 
+    /**
+     * deprecated by libgit2 1.8.x
+     * @param klass
+     * @param message
+     */
+    @Deprecated
     static native void jniSetStr(int klass, String message);
 
     /**

--- a/src/main/java/com/github/git24j/core/FetchOptions.java
+++ b/src/main/java/com/github/git24j/core/FetchOptions.java
@@ -43,6 +43,7 @@ public class FetchOptions extends CAutoReleasable {
     public void setDepth(int depth) {
         jniFetchOptionsSetDepth(getRawPointer(), depth);
     }
+
     public RedirectT getFollowRedirects() {
         int r = jniFetchOptionsGetFollowRedirects(getRawPointer());
         return IBitEnum.valueOf(r, RedirectT.class);
@@ -127,5 +128,17 @@ public class FetchOptions extends CAutoReleasable {
         PRUNE,
         /** Force pruning off */
         NO_PRUNE,
+    }
+
+
+    /** Constants for fetch depth (shallowness of fetch).
+     *  `git_fetch_depth_t` in libgit2
+     * */
+    public static class DepthT{
+        /** The fetch is "full" (not shallow). This is the default. */
+        public static final int FULL = 0;  // libgit2: `GIT_FETCH_DEPTH_FULL`
+
+        /** The fetch should "unshallow" and fetch missing data. */
+        public static final int UNSHALLOW = 2147483647;  // libgit2: `GIT_FETCH_DEPTH_UNSHALLOW`
     }
 }

--- a/src/main/java/com/github/git24j/core/GitException.java
+++ b/src/main/java/com/github/git24j/core/GitException.java
@@ -98,8 +98,20 @@ public class GitException extends RuntimeException {
         EINDEXDIRTY(-34),
         /** < Patch application failed */
         EAPPLYFAIL(-35),
+        /**< The object is not owned by the current user */
+        EOWNER(-36),
+        /**< The operation timed out */
+        TIMEOUT(-37),
+        /**< There were no changes */
+        EUNCHANGED(-38),
+        /**< An option is not supported */
+        ENOTSUPPORTED(-39),
+        /**< The subject is read-only */
+        EREADONLY(-40),
+
         /** < undefined code in the libgit2, because of a version mismatch? */
         UNKNOWN(-9999);
+
         private final int code;
 
         ErrorCode(int code) {
@@ -121,7 +133,7 @@ public class GitException extends RuntimeException {
         }
     }
 
-    /** Error classes */
+    /** Error classes, src: `git_error_t` in "libgit2/include/git2/errors.h" */
     public enum ErrorClass {
         NONE,
         NOMEMORY,
@@ -156,7 +168,10 @@ public class GitException extends RuntimeException {
         FILESYSTEM,
         PATCH,
         WORKTREE,
-        SHA1;
+        SHA,
+        HTTP,
+        INTERNAL,
+        GRAFTS;
 
         /**
          * Derive ErrorClass from ordinal index.

--- a/src/main/java/com/github/git24j/core/Index.java
+++ b/src/main/java/com/github/git24j/core/Index.java
@@ -58,7 +58,7 @@ public class Index extends CAutoReleasable {
 
     static native int jniEntryCount(long indexPtr);
 
-    static native int jniEntryFree(long entryPtr);
+    static native void jniEntryFree(long entryPtr);
 
     /** int ctime_nanoseconds */
     static native long jniEntryGetCtimeNanoseconds(long entryPtr);
@@ -161,7 +161,7 @@ public class Index extends CAutoReleasable {
 
     static native int jniHasConflicts(long indexPtr);
 
-    static native int jniIteratorFree(long iterPtr);
+    static native void jniIteratorFree(long iterPtr);
 
     static native int jniIteratorNew(AtomicLong outIterPtr, long indexPtr);
 

--- a/src/main/java/com/github/git24j/core/Index.java
+++ b/src/main/java/com/github/git24j/core/Index.java
@@ -977,7 +977,7 @@ public class Index extends CAutoReleasable {
 
         @Override
         protected void finalize() throws Throwable {
-            if (_ptr.get() > 0) {
+            if (_ptr.get() != 0) {
                 jniConflictIteratorFree(_ptr.get());
             }
             super.finalize();

--- a/src/main/java/com/github/git24j/core/Mailmap.java
+++ b/src/main/java/com/github/git24j/core/Mailmap.java
@@ -70,7 +70,7 @@ public class Mailmap {
 
     @Override
     protected void finalize() throws Throwable {
-        if (_rawPtr.get() > 0) {
+        if (_rawPtr.get() != 0) {
             jniFree(_rawPtr.getAndSet(0));
         }
         super.finalize();

--- a/src/main/java/com/github/git24j/core/Merge.java
+++ b/src/main/java/com/github/git24j/core/Merge.java
@@ -86,7 +86,7 @@ public class Merge {
     /** int git_merge_file_init_options(git_merge_file_options *opts, unsigned int version); */
     static native int jniFileInitOptions(long opts, int version);
 
-    static native int jniFileInputFree(long optsPtr);
+    static native void jniFileInputFree(long optsPtr);
 
     /** int mode */
     static native int jniFileInputGetMode(long file_inputPtr);
@@ -120,7 +120,7 @@ public class Merge {
     /** unsigned int version */
     static native void jniFileInputSetVersion(long file_inputPtr, int version);
 
-    static native int jniFileOptionsFree(long opts);
+    static native void jniFileOptionsFree(long opts);
 
     /** const char *ancestor_label */
     static native String jniFileOptionsGetAncestorLabel(long file_optionsPtr);

--- a/src/main/java/com/github/git24j/core/Oid.java
+++ b/src/main/java/com/github/git24j/core/Oid.java
@@ -4,6 +4,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * An Oid is a 20 bytes array (each byte coded 32bit), or a 40 hex characters string (16 bit coded)
@@ -39,7 +40,8 @@ public class Oid {
     }
 
     public static Oid of(@Nonnull String hexSha) {
-        byte[] bytes = hexStringToByteArray(hexSha.toLowerCase());
+        // kotlin default `String.lowercase()` use `Local.ROOT`, maybe more compatible and less err? idk, just use it
+        byte[] bytes = hexStringToByteArray(hexSha.toLowerCase(Locale.ROOT));
         return new Oid(bytes);
     }
 

--- a/src/main/java/com/github/git24j/core/PackBuilder.java
+++ b/src/main/java/com/github/git24j/core/PackBuilder.java
@@ -5,6 +5,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class PackBuilder extends CAutoReleasable {
+
     /** int git_packbuilder_foreach(git_packbuilder *pb, git_packbuilder_foreach_cb * cb); */
     static native int jniForeach(long pb, Internals.BArrCallback cb);
 

--- a/src/main/java/com/github/git24j/core/PushOptions.java
+++ b/src/main/java/com/github/git24j/core/PushOptions.java
@@ -5,16 +5,7 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.github.git24j.core.Remote.jniPushOptionsFree;
-import static com.github.git24j.core.Remote.jniPushOptionsGetCallbacks;
-import static com.github.git24j.core.Remote.jniPushOptionsGetCustomHeaders;
-import static com.github.git24j.core.Remote.jniPushOptionsGetPbParallelism;
-import static com.github.git24j.core.Remote.jniPushOptionsGetProxyOpts;
-import static com.github.git24j.core.Remote.jniPushOptionsGetVersion;
-import static com.github.git24j.core.Remote.jniPushOptionsNew;
-import static com.github.git24j.core.Remote.jniPushOptionsSetCustomHeaders;
-import static com.github.git24j.core.Remote.jniPushOptionsSetPbParallelism;
-import static com.github.git24j.core.Remote.jniPushOptionsSetVersion;
+import static com.github.git24j.core.Remote.*;
 
 public class PushOptions extends CAutoReleasable {
     public static final int VERSION = 1;
@@ -78,5 +69,16 @@ public class PushOptions extends CAutoReleasable {
 
     public void setCustomHeaders(String[] customHeaders) {
         jniPushOptionsSetCustomHeaders(getRawPointer(), customHeaders);
+    }
+
+    @Nonnull
+    public List<String> getRemotePushOptions() {
+        List<String> out = new ArrayList<>();
+        jniPushOptionsGetRemotePushOptions(getRawPointer(), out);
+        return out;
+    }
+
+    public void setRemotePushOptions(String[] remotePushOptions) {
+        jniPushOptionsSetRemotePushOptions(getRawPointer(), remotePushOptions);
     }
 }

--- a/src/main/java/com/github/git24j/core/Rebase.java
+++ b/src/main/java/com/github/git24j/core/Rebase.java
@@ -8,6 +8,9 @@ import javax.annotation.Nullable;
 
 public class Rebase extends CAutoReleasable {
 
+        /** void *payload */
+    static native void jniOptionsSetPayload(long optionsPtr, long payload);
+
     /** int git_rebase_abort(git_rebase *rebase); */
     static native int jniAbort(long rebase);
 
@@ -394,9 +397,6 @@ public class Rebase extends CAutoReleasable {
      */
     public static class Options extends CAutoReleasable {
         public static final int VERSION = 1;
-
-        /** void *payload */
-        static native void jniOptionsSetPayload(long optionsPtr, long payload);
 
         protected Options(boolean isWeak, long rawPtr) {
             super(isWeak, rawPtr);

--- a/src/main/java/com/github/git24j/core/Rebase.java
+++ b/src/main/java/com/github/git24j/core/Rebase.java
@@ -393,6 +393,8 @@ public class Rebase extends CAutoReleasable {
      * <p>Use to tell the rebase machinery how to operate.
      */
     public static class Options extends CAutoReleasable {
+        public static final int VERSION = 1;
+
         /** void *payload */
         static native void jniOptionsSetPayload(long optionsPtr, long payload);
 
@@ -405,6 +407,10 @@ public class Rebase extends CAutoReleasable {
             Options opts = new Options(false, 0);
             Error.throwIfNeeded(jniOptionsNew(opts._rawPtr, version));
             return opts;
+        }
+
+        public static Options createDefault() {
+            return create(VERSION);
         }
 
         @Override

--- a/src/main/java/com/github/git24j/core/Reference.java
+++ b/src/main/java/com/github/git24j/core/Reference.java
@@ -653,7 +653,7 @@ public class Reference extends CAutoReleasable {
     public Reference resolve() {
         AtomicLong outRef = new AtomicLong();
         Error.throwIfNeeded(jniResolve(outRef, getRawPointer()));
-        return outRef.get() > 0 ? new Reference(false, outRef.get()) : null;
+        return outRef.get() != 0 ? new Reference(false, outRef.get()) : null;
     }
 
     /**
@@ -687,7 +687,7 @@ public class Reference extends CAutoReleasable {
     public Reference symbolicSetTarget(@Nonnull String target, @Nonnull String logMessage) {
         AtomicLong outRef = new AtomicLong();
         Error.throwIfNeeded(jniSymbolicSetTarget(outRef, getRawPointer(), target, logMessage));
-        return outRef.get() > 0 ? new Reference(false, outRef.get()) : null;
+        return outRef.get() != 0 ? new Reference(false, outRef.get()) : null;
     }
 
     /**

--- a/src/main/java/com/github/git24j/core/Reference.java
+++ b/src/main/java/com/github/git24j/core/Reference.java
@@ -922,12 +922,12 @@ public class Reference extends CAutoReleasable {
 
     @FunctionalInterface
     public interface ForeachNameCb {
-        public int accept(String name);
+        int accept(String name);
     }
 
     @FunctionalInterface
     public interface ForeachCb {
-        public int accept(long refPtr);
+        int accept(long refPtr);
     }
 
     public static class Iterator extends CAutoReleasable {

--- a/src/main/java/com/github/git24j/core/Reference.java
+++ b/src/main/java/com/github/git24j/core/Reference.java
@@ -922,12 +922,12 @@ public class Reference extends CAutoReleasable {
 
     @FunctionalInterface
     public interface ForeachNameCb {
-        int accept(String name);
+        public int accept(String name);
     }
 
     @FunctionalInterface
     public interface ForeachCb {
-        int accept(long refPtr);
+        public int accept(long refPtr);
     }
 
     public static class Iterator extends CAutoReleasable {

--- a/src/main/java/com/github/git24j/core/Reflog.java
+++ b/src/main/java/com/github/git24j/core/Reflog.java
@@ -48,7 +48,7 @@ public class Reflog extends CAutoReleasable {
      * int git_transaction_set_reflog(git_transaction *tx, const char *refname, const git_reflog
      * *reflog);
      */
-    static native int jniSetReflog(long tx, String refname, long reflog);
+//    static native int jniSetReflog(long tx, String refname, long reflog);
 
     /** int git_reflog_write(git_reflog *reflog); */
     static native int jniWrite(long reflog);
@@ -90,9 +90,9 @@ public class Reflog extends CAutoReleasable {
         return reflog;
     }
 
-    public void transactionSetReflog(@Nonnull Transaction tx, @Nonnull String refname) {
-        Error.throwIfNeeded(jniSetReflog(tx.getRawPointer(), refname, getRawPointer()));
-    }
+//    public void transactionSetReflog(@Nonnull Transaction tx, @Nonnull String refname) {
+//        Error.throwIfNeeded(jniSetReflog(tx.getRawPointer(), refname, getRawPointer()));
+//    }
 
     public void write() {
         Error.throwIfNeeded(jniWrite(getRawPointer()));

--- a/src/main/java/com/github/git24j/core/Remote.java
+++ b/src/main/java/com/github/git24j/core/Remote.java
@@ -168,7 +168,10 @@ public class Remote extends CAutoReleasable {
     static native int jniFetchOptionsNew(AtomicLong outPtr, int version);
 
     /** git_remote_callbacks callbacks */
-    static native void jniFetchOptionsSetCallbacks(long fetch_optionsPtr, Callbacks callbacks);
+//    static native void jniFetchOptionsSetCallbacks(long fetch_optionsPtr, Callbacks callbacks);
+
+    /** git_remote_init_callbacks */
+    static native int jniInitCallbacks(long remoteCallbacksPtr, int version);
 
     /** git_strarray custom_headers */
     static native void jniFetchOptionsSetCustomHeaders(

--- a/src/main/java/com/github/git24j/core/Remote.java
+++ b/src/main/java/com/github/git24j/core/Remote.java
@@ -28,8 +28,7 @@ public class Remote extends CAutoReleasable {
 
     static native int jniCallbacksNew(AtomicLong outCb, int version);
 
-    static native void jniCallbacksSetCallbackObject(
-            long cbsPtr, Callbacks cbsObject, int callbackType);
+    static native void jniCallbacksSetCallbackObject(long cbsPtr, Callbacks cbsObject, int callbackType);
 
     static native void jniCallbacksTest(long cbsPtr, Callbacks callbacks);
 
@@ -63,7 +62,7 @@ public class Remote extends CAutoReleasable {
     /** int git_remote_create_detached(git_remote **out, const char *url); */
     static native int jniCreateDetached(AtomicLong out, String url);
 
-    static native int jniCreateOptionsFree(long optsPtr);
+    static native void jniCreateOptionsFree(long optsPtr);
 
     /** const char *fetchspec */
     static native String jniCreateOptionsGetFetchspec(long create_optionsPtr);
@@ -134,7 +133,7 @@ public class Remote extends CAutoReleasable {
      */
     static native int jniFetch(long remote, String[] refspecs, long opts, String reflogMessage);
 
-    static native int jniFetchOptionsFree(long ptr);
+    static native void jniFetchOptionsFree(long ptr);
 
     /** git_remote_callbacks callbacks */
     static native long jniFetchOptionsGetCallbacks(long fetch_optionsPtr);
@@ -264,7 +263,7 @@ public class Remote extends CAutoReleasable {
     /** unsigned int version */
     static native void jniPushOptionsSetVersion(long push_optionsPtr, int version);
 
-    static native char jniPushUpdateFree(long push_updatePtr);
+    static native void jniPushUpdateFree(long push_updatePtr);
 
     /** git_oid dst */
     static native byte[] jniPushUpdateGetDst(long push_updatePtr);

--- a/src/main/java/com/github/git24j/core/Remote.java
+++ b/src/main/java/com/github/git24j/core/Remote.java
@@ -1423,7 +1423,7 @@ public class Remote extends CAutoReleasable {
          *
          * @return 0 if no credential was acquired, > 0 if credentials acquired successfully, < 0 will not happened
          */
-        long acquireCred(String url, String usernameFromUrl, int allowedTypes) {
+        public long acquireCred(String url, String usernameFromUrl, int allowedTypes) {
             if (_credAcquireCb != null) {
                 return Optional.ofNullable(
                                 _credAcquireCb.acquire(url, usernameFromUrl, allowedTypes))
@@ -1433,14 +1433,14 @@ public class Remote extends CAutoReleasable {
             return 0;
         }
 
-        int transportMessage(String message) {
+        public int transportMessage(String message) {
             if (_transportMsg != null) {
                 return _transportMsg.accept(message);
             }
             return 0;
         }
 
-        int complete(int type) {
+        public int complete(int type) {
             if (_completionCb != null) {
                 CompletionT completionT =
                         type == 0
@@ -1451,7 +1451,7 @@ public class Remote extends CAutoReleasable {
             return 0;
         }
 
-        int transportMessageCheck(long certPtr, int valid, String host) {
+        public int transportMessageCheck(long certPtr, int valid, String host) {
             if (_certificateCheckCb != null) {
                 Cert cert = certPtr == 0 ? null : new Cert(true, certPtr);
                 return _certificateCheckCb.accept(cert, valid != 0, host);
@@ -1459,7 +1459,7 @@ public class Remote extends CAutoReleasable {
             return 0;
         }
 
-        int transferProgress(long progressPtr) {
+        public int transferProgress(long progressPtr) {
             if (_transferProgressCb != null) {
                 TransferProgress progress =
                         progressPtr == 0 ? null : new TransferProgress(true, progressPtr);
@@ -1468,7 +1468,7 @@ public class Remote extends CAutoReleasable {
             return 0;
         }
 
-        int updateTips(String refname, byte[] ida, byte[] idb) {
+        public int updateTips(String refname, byte[] ida, byte[] idb) {
             if (_updateTipsCb != null) {
                 Oid oida = ida == null ? null : Oid.of(ida);
                 Oid oidb = idb == null ? null : Oid.of(idb);
@@ -1477,28 +1477,28 @@ public class Remote extends CAutoReleasable {
             return 0;
         }
 
-        int packProgress(int stage, long current, long total) {
+        public int packProgress(int stage, long current, long total) {
             if (_packProgressCb != null) {
                 return _packProgressCb.accept(stage, current, total);
             }
             return 0;
         }
 
-        int pushTransferProgress(long current, long total, int bytes) {
+        public int pushTransferProgress(long current, long total, int bytes) {
             if (_pushTransferProgressCb != null) {
                 return _pushTransferProgressCb.accept(current, total, bytes);
             }
             return 0;
         }
 
-        int pushUpdateReference(String refname, String status) {
+        public int pushUpdateReference(String refname, String status) {
             if (_pushUpdateReferenceCb != null) {
                 return _pushUpdateReferenceCb.accept(refname, status);
             }
             return 0;
         }
 
-        int pushNegotiation(long[] updates) {
+        public int pushNegotiation(long[] updates) {
             if (_pushNegotiationCb != null) {
                 if (updates == null) {
                     return _pushNegotiationCb.accept(Collections.emptyList());
@@ -1511,7 +1511,7 @@ public class Remote extends CAutoReleasable {
             return 0;
         }
 
-        int resolveUrl(String resolvedUrl, String url, int direction) {
+        public int resolveUrl(String resolvedUrl, String url, int direction) {
             if (_urlResolveCb != null) {
                 return _urlResolveCb.accept(
                         resolvedUrl, url, direction == 0 ? Direction.FETCH : Direction.PUSH);
@@ -1533,7 +1533,7 @@ public class Remote extends CAutoReleasable {
          * @param ownerPtr
          * @return <0 for error,
          */
-        long transport(long ownerPtr) {
+        public long transport(long ownerPtr) {
             if (_transportCb != null) {
                 Remote remote = ownerPtr == 0 ? null : new Remote(true, ownerPtr);
                 return Optional.ofNullable(_transportCb.accept(remote))

--- a/src/main/java/com/github/git24j/core/Remote.java
+++ b/src/main/java/com/github/git24j/core/Remote.java
@@ -861,11 +861,12 @@ public class Remote extends CAutoReleasable {
      *
      * <p>If url.*.pushInsteadOf has been configured for this URL, it will return the modified URL.
      *
-     * @return the url or empty if no special url for pushing is set
+     * @return the url or null if no special url for pushing is set
      */
     @Nullable
-    public URI pushurl() {
-        return Optional.ofNullable(jniPushurl(getRawPointer())).map(URI::create).orElse(null);
+    public String pushurl() {
+//        return Optional.ofNullable(jniPushurl(getRawPointer())).map(URI::create).orElse(null);
+        return jniPushurl(getRawPointer());
     }
 
     /**
@@ -950,12 +951,12 @@ public class Remote extends CAutoReleasable {
      *
      * <p>If url.*.insteadOf has been configured for this URL, it will return the modified URL.
      *
-     * @return URI that represents the url
-     * @throws IllegalStateException if remote url is not a valid URI
+     * @return the url string
      */
     @Nonnull
-    public URI url() {
-        return URI.create(jniUrl(getRawPointer()));
+    public String url() {
+        String url = jniUrl(getRawPointer());
+        return url==null ? "" : url;
     }
 
     public enum AutotagOptionT implements IBitEnum {

--- a/src/main/java/com/github/git24j/core/Remote.java
+++ b/src/main/java/com/github/git24j/core/Remote.java
@@ -1423,7 +1423,8 @@ public class Remote extends CAutoReleasable {
          *
          * @return 0 if no credential was acquired, > 0 if credentials acquired successfully, < 0 will not happened
          */
-        public long acquireCred(String url, String usernameFromUrl, int allowedTypes) {
+        //this method only used by jni, so set it to private is ok
+        private long acquireCred(String url, String usernameFromUrl, int allowedTypes) {
             if (_credAcquireCb != null) {
                 return Optional.ofNullable(
                                 _credAcquireCb.acquire(url, usernameFromUrl, allowedTypes))
@@ -1433,14 +1434,14 @@ public class Remote extends CAutoReleasable {
             return 0;
         }
 
-        public int transportMessage(String message) {
+        private int transportMessage(String message) {
             if (_transportMsg != null) {
                 return _transportMsg.accept(message);
             }
             return 0;
         }
 
-        public int complete(int type) {
+        private int complete(int type) {
             if (_completionCb != null) {
                 CompletionT completionT =
                         type == 0
@@ -1451,7 +1452,7 @@ public class Remote extends CAutoReleasable {
             return 0;
         }
 
-        public int transportMessageCheck(long certPtr, int valid, String host) {
+        private int transportMessageCheck(long certPtr, int valid, String host) {
             if (_certificateCheckCb != null) {
                 Cert cert = certPtr == 0 ? null : new Cert(true, certPtr);
                 return _certificateCheckCb.accept(cert, valid != 0, host);
@@ -1459,7 +1460,7 @@ public class Remote extends CAutoReleasable {
             return 0;
         }
 
-        public int transferProgress(long progressPtr) {
+        private int transferProgress(long progressPtr) {
             if (_transferProgressCb != null) {
                 TransferProgress progress =
                         progressPtr == 0 ? null : new TransferProgress(true, progressPtr);
@@ -1468,7 +1469,7 @@ public class Remote extends CAutoReleasable {
             return 0;
         }
 
-        public int updateTips(String refname, byte[] ida, byte[] idb) {
+        private int updateTips(String refname, byte[] ida, byte[] idb) {
             if (_updateTipsCb != null) {
                 Oid oida = ida == null ? null : Oid.of(ida);
                 Oid oidb = idb == null ? null : Oid.of(idb);
@@ -1477,28 +1478,28 @@ public class Remote extends CAutoReleasable {
             return 0;
         }
 
-        public int packProgress(int stage, long current, long total) {
+        private int packProgress(int stage, long current, long total) {
             if (_packProgressCb != null) {
                 return _packProgressCb.accept(stage, current, total);
             }
             return 0;
         }
 
-        public int pushTransferProgress(long current, long total, int bytes) {
+        private int pushTransferProgress(long current, long total, int bytes) {
             if (_pushTransferProgressCb != null) {
                 return _pushTransferProgressCb.accept(current, total, bytes);
             }
             return 0;
         }
 
-        public int pushUpdateReference(String refname, String status) {
+        private int pushUpdateReference(String refname, String status) {
             if (_pushUpdateReferenceCb != null) {
                 return _pushUpdateReferenceCb.accept(refname, status);
             }
             return 0;
         }
 
-        public int pushNegotiation(long[] updates) {
+        private int pushNegotiation(long[] updates) {
             if (_pushNegotiationCb != null) {
                 if (updates == null) {
                     return _pushNegotiationCb.accept(Collections.emptyList());
@@ -1511,7 +1512,7 @@ public class Remote extends CAutoReleasable {
             return 0;
         }
 
-        public int resolveUrl(String resolvedUrl, String url, int direction) {
+        private int resolveUrl(String resolvedUrl, String url, int direction) {
             if (_urlResolveCb != null) {
                 return _urlResolveCb.accept(
                         resolvedUrl, url, direction == 0 ? Direction.FETCH : Direction.PUSH);
@@ -1533,7 +1534,7 @@ public class Remote extends CAutoReleasable {
          * @param ownerPtr
          * @return <0 for error,
          */
-        public long transport(long ownerPtr) {
+        private long transport(long ownerPtr) {
             if (_transportCb != null) {
                 Remote remote = ownerPtr == 0 ? null : new Remote(true, ownerPtr);
                 return Optional.ofNullable(_transportCb.accept(remote))

--- a/src/main/java/com/github/git24j/core/Remote.java
+++ b/src/main/java/com/github/git24j/core/Remote.java
@@ -2,7 +2,6 @@ package com.github.git24j.core;
 
 import static com.github.git24j.core.GitException.ErrorCode.ENOTFOUND;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -390,9 +389,9 @@ public class Remote extends CAutoReleasable {
      * @throws GitException GIT_EINVALIDSPEC, GIT_EEXISTS or an error code
      */
     @Nonnull
-    public static Remote create(@Nonnull Repository repo, @Nonnull String name, @Nonnull URI url) {
+    public static Remote create(@Nonnull Repository repo, @Nonnull String name, @Nonnull String url) {
         Remote remote = new Remote(false, 0);
-        Error.throwIfNeeded(jniCreate(remote._rawPtr, repo.getRawPointer(), name, url.toString()));
+        Error.throwIfNeeded(jniCreate(remote._rawPtr, repo.getRawPointer(), name, url));
         return remote;
     }
 
@@ -408,10 +407,10 @@ public class Remote extends CAutoReleasable {
      * @throws GitException git errors
      */
     @Nonnull
-    public static Remote createAnonymous(@Nonnull Repository repo, @Nonnull URI url) {
+    public static Remote createAnonymous(@Nonnull Repository repo, @Nonnull String url) {
         Remote remote = new Remote(false, 0);
         Error.throwIfNeeded(
-                jniCreateAnonymous(remote._rawPtr, repo.getRawPointer(), url.toString()));
+                jniCreateAnonymous(remote._rawPtr, repo.getRawPointer(), url));
         return remote;
     }
 
@@ -429,9 +428,9 @@ public class Remote extends CAutoReleasable {
      * @throws GitException git errors
      */
     @Nonnull
-    public static Remote createDetached(@Nonnull URI url) {
+    public static Remote createDetached(@Nonnull String url) {
         Remote remote = new Remote(false, 0);
-        Error.throwIfNeeded(jniCreateDetached(remote._rawPtr, url.toString()));
+        Error.throwIfNeeded(jniCreateDetached(remote._rawPtr, url));
         return remote;
     }
 
@@ -450,12 +449,12 @@ public class Remote extends CAutoReleasable {
     public static Remote createWithFetchspec(
             @Nonnull Repository repo,
             @Nonnull String name,
-            @Nonnull URI url,
+            @Nonnull String url,
             @Nullable String fetch) {
         Remote remote = new Remote(false, 0);
         Error.throwIfNeeded(
                 jniCreateWithFetchspec(
-                        remote._rawPtr, repo.getRawPointer(), name, url.toString(), fetch));
+                        remote._rawPtr, repo.getRawPointer(), name, url, fetch));
         return remote;
     }
 
@@ -472,11 +471,11 @@ public class Remote extends CAutoReleasable {
      * @throws GitException GIT_EINVALIDSPEC, GIT_EEXISTS or an error code
      */
     @Nonnull
-    public static Remote createWithOpts(@Nonnull URI url, @Nullable CreateOptions opts) {
+    public static Remote createWithOpts(@Nonnull String url, @Nullable CreateOptions opts) {
         Remote remote = new Remote(false, 0);
         Error.throwIfNeeded(
                 jniCreateWithOpts(
-                        remote._rawPtr, url.toString(), opts == null ? 0 : opts.getRawPointer()));
+                        remote._rawPtr, url, opts == null ? 0 : opts.getRawPointer()));
         return remote;
     }
 
@@ -583,9 +582,9 @@ public class Remote extends CAutoReleasable {
      * @throws GitException git errors
      */
     public static void setPushurl(
-            @Nonnull Repository repo, @Nonnull String remote, @Nullable URI url) {
+            @Nonnull Repository repo, @Nonnull String remote, @Nullable String url) {
         Error.throwIfNeeded(
-                jniSetPushurl(repo.getRawPointer(), remote, url == null ? null : url.toString()));
+                jniSetPushurl(repo.getRawPointer(), remote, url));
     }
 
     /**
@@ -599,9 +598,9 @@ public class Remote extends CAutoReleasable {
      * @param url the url to set, null to delete the remote from config
      * @throws GitException git errors
      */
-    public static void setUrl(@Nonnull Repository repo, @Nonnull String remote, @Nullable URI url) {
+    public static void setUrl(@Nonnull Repository repo, @Nonnull String remote, @Nullable String url) {
         Error.throwIfNeeded(
-                jniSetUrl(repo.getRawPointer(), remote, url == null ? null : url.toString()));
+                jniSetUrl(repo.getRawPointer(), remote, url));
     }
 
     @Override

--- a/src/main/java/com/github/git24j/core/Remote.java
+++ b/src/main/java/com/github/git24j/core/Remote.java
@@ -251,6 +251,14 @@ public class Remote extends CAutoReleasable {
     /** git_strarray custom_headers */
     static native void jniPushOptionsSetCustomHeaders(long push_optionsPtr, String[] customHeaders);
 
+    /**
+     * "Push options" to deliver to the remote.
+     *
+     * @since libgit2 1.8
+     */
+    static native void jniPushOptionsSetRemotePushOptions(long push_optionsPtr, String[] remotePushOptions);
+    static native void jniPushOptionsGetRemotePushOptions(long push_optionsPtr, List<String> outRemotePushOptions);
+
     /** unsigned int pb_parallelism */
     static native void jniPushOptionsSetPbParallelism(long push_optionsPtr, int pbParallelism);
 

--- a/src/main/java/com/github/git24j/core/Repository.java
+++ b/src/main/java/com/github/git24j/core/Repository.java
@@ -25,7 +25,7 @@ public class Repository extends CAutoCloseable {
 
     static native int jniFetchheadForeach(long repoPtr, FetchHeadForeachCb cb);
 
-    static native int jniFree(long repoPtr);
+    static native void jniFree(long repoPtr);
 
     static native String jniGetNamespace(long repoPtr);
 

--- a/src/main/java/com/github/git24j/core/Repository.java
+++ b/src/main/java/com/github/git24j/core/Repository.java
@@ -474,6 +474,12 @@ public class Repository extends CAutoCloseable {
         return jniIsShallow(getRawPointer()) == 1;
     }
 
+    /** backward compatible, please use `isShallow()` instead */
+    @Deprecated
+    public boolean isShadow() {
+        return isShallow();
+    }
+
     //
     //    static native int jniIdent(
     //            AtomicReference<String> outName, AtomicReference<String> outEmail, long repoPtr);

--- a/src/main/java/com/github/git24j/core/Repository.java
+++ b/src/main/java/com/github/git24j/core/Repository.java
@@ -916,7 +916,8 @@ public class Repository extends CAutoCloseable {
     }
 
     public abstract static class FetchHeadForeachCb {
-        public int accept(String remoteUrl, byte[] oidRaw, int isMerge) {
+        // this method only used by jni, so set it to private is ok, user should overwrite `call` method
+        private int accept(String remoteUrl, byte[] oidRaw, int isMerge) {
             return call(remoteUrl, Oid.of(oidRaw), isMerge == 1);
         }
 
@@ -932,7 +933,7 @@ public class Repository extends CAutoCloseable {
     }
 
     public abstract static class MergeheadForeachCb {
-        public int accept(byte[] oidRaw) {
+        private int accept(byte[] oidRaw) {
             return call(Oid.of(oidRaw));
         }
 

--- a/src/main/java/com/github/git24j/core/Repository.java
+++ b/src/main/java/com/github/git24j/core/Repository.java
@@ -53,7 +53,7 @@ public class Repository extends CAutoCloseable {
 
     static native int jniIsEmpty(long repoPtr);
 
-    static native int jniIsShadow(long repoPtr);
+    static native int jniIsShallow(long repoPtr);
 
     static native int jniIsWorktree(long repoPtr);
 
@@ -470,8 +470,8 @@ public class Repository extends CAutoCloseable {
     }
 
     /** Determine if the repository was a shallow clone. */
-    public boolean isShadow() {
-        return jniIsShadow(getRawPointer()) == 1;
+    public boolean isShallow() {
+        return jniIsShallow(getRawPointer()) == 1;
     }
 
     //

--- a/src/main/java/com/github/git24j/core/Repository.java
+++ b/src/main/java/com/github/git24j/core/Repository.java
@@ -916,7 +916,7 @@ public class Repository extends CAutoCloseable {
     }
 
     public abstract static class FetchHeadForeachCb {
-        int accept(String remoteUrl, byte[] oidRaw, int isMerge) {
+        public int accept(String remoteUrl, byte[] oidRaw, int isMerge) {
             return call(remoteUrl, Oid.of(oidRaw), isMerge == 1);
         }
 
@@ -932,7 +932,7 @@ public class Repository extends CAutoCloseable {
     }
 
     public abstract static class MergeheadForeachCb {
-        int accept(byte[] oidRaw) {
+        public int accept(byte[] oidRaw) {
             return call(Oid.of(oidRaw));
         }
 

--- a/src/main/java/com/github/git24j/core/Repository.java
+++ b/src/main/java/com/github/git24j/core/Repository.java
@@ -523,7 +523,7 @@ public class Repository extends CAutoCloseable {
 
     /** Close the repository, no-op if not opened. */
     public void free() {
-        if (_rawPtr.get() > 0) {
+        if (_rawPtr.get() != 0) {
             jniFree(_rawPtr.getAndSet(0));
         }
     }

--- a/src/main/java/com/github/git24j/core/Repository.java
+++ b/src/main/java/com/github/git24j/core/Repository.java
@@ -116,15 +116,15 @@ public class Repository extends CAutoCloseable {
      */
     @Nonnull
     public static Repository open(@Nonnull Path path) {
-        AtomicLong outRepo = new AtomicLong();
-        int error = jniOpen(outRepo, path.toString());
-        Error.throwIfNeeded(error);
-        return new Repository(outRepo.get());
+        return open(path.toString());
     }
 
     @Nonnull
     public static Repository open(@Nonnull String path) {
-        return open(Paths.get(path));
+        AtomicLong outRepo = new AtomicLong();
+        int error = jniOpen(outRepo, path);
+        Error.throwIfNeeded(error);
+        return new Repository(outRepo.get());
     }
 
     /**
@@ -241,10 +241,9 @@ public class Repository extends CAutoCloseable {
      *
      * @return the path to the working dir, if it exists
      */
-    @Nonnull
-    public Path workdir() {
-        String wd = jniWorkdir(getRawPointer());
-        return Paths.get(wd);
+    @CheckForNull
+    public String workdir() {
+        return jniWorkdir(getRawPointer());
     }
 
     /**
@@ -647,6 +646,7 @@ public class Repository extends CAutoCloseable {
         return Objects.hashCode(getPath());
     }
 
+    // https://libgit2.org/docs/reference/main/repository/git_repository_item_t.html
     public enum Item {
         GITDIR,
         WORKDIR,
@@ -662,6 +662,7 @@ public class Repository extends CAutoCloseable {
         LOGS,
         MODULES,
         WORKTREES,
+        WORKTREE_CONFIG,
         LAST
     }
 

--- a/src/main/java/com/github/git24j/core/Revparse.java
+++ b/src/main/java/com/github/git24j/core/Revparse.java
@@ -45,8 +45,8 @@ public class Revparse {
         AtomicLong outRef = new AtomicLong();
         Error.throwIfNeeded(jniExt(outObj, outRef, repository.getRawPointer(), spec));
         return new ExtReturn(
-                outObj.get() > 0 ? new GitObject(false, outObj.get()) : null,
-                outRef.get() > 0 ? new Reference(false, outRef.get()) : null);
+                outObj.get() != 0 ? new GitObject(false, outObj.get()) : null,
+                outRef.get() != 0 ? new Reference(false, outRef.get()) : null);
     }
 
     public enum Mode implements IBitEnum {

--- a/src/main/java/com/github/git24j/core/Revwalk.java
+++ b/src/main/java/com/github/git24j/core/Revwalk.java
@@ -18,7 +18,7 @@ public class Revwalk extends CAutoReleasable {
     /** void git_revwalk_free(git_revwalk *walk); */
     static native void jniFree(long walk);
 
-    static native int jniFreeHideCb(long payloadPtr);
+    static native void jniFreeHideCb(long payloadPtr);
 
     /** int git_revwalk_hide(git_revwalk *walk, const git_oid *commit_id); */
     static native int jniHide(long walk, Oid commitId);

--- a/src/main/java/com/github/git24j/core/Signature.java
+++ b/src/main/java/com/github/git24j/core/Signature.java
@@ -160,8 +160,27 @@ public class Signature extends CAutoReleasable {
 
     @Nonnull
     public OffsetDateTime getWhen() {
-        ZoneOffset offset = ZoneOffset.ofTotalSeconds(jniGetOffsetMinutes(getRawPointer()) * 60);
-        return Instant.ofEpochSecond(jniGetEpocSeconds(getRawPointer())).atOffset(offset);
+        return getWhenWithOffset(null);
+    }
+
+    /**
+     *
+     * @param timezoneOffsetInMinutes if null, will use offset from signature
+     * @return
+    */
+    @Nonnull
+    public OffsetDateTime getWhenWithOffset(@Nullable Integer timezoneOffsetInMinutes) {
+        int minutes = timezoneOffsetInMinutes==null ? timeOffsetInMinutes() : timezoneOffsetInMinutes;
+        ZoneOffset offset = ZoneOffset.ofTotalSeconds(minutes * 60);
+        return Instant.ofEpochSecond(timeInUtcSeconds()).atOffset(offset);
+    }
+
+    public Integer timeOffsetInMinutes() {
+        return jniGetOffsetMinutes(getRawPointer());
+    }
+
+    public Long timeInUtcSeconds() {
+        return jniGetEpocSeconds(getRawPointer());
     }
 
     @Override
@@ -171,11 +190,13 @@ public class Signature extends CAutoReleasable {
         Signature signature = (Signature) o;
         return Objects.equals(getName(), signature.getName())
                 && Objects.equals(getEmail(), signature.getEmail())
-                && Objects.equals(getWhen(), signature.getWhen());
+                && Objects.equals(timeOffsetInMinutes(), signature.timeOffsetInMinutes())
+                && Objects.equals(timeInUtcSeconds(), signature.timeInUtcSeconds())
+                ;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getName(), getEmail(), getWhen());
+        return Objects.hash(getName(), getEmail(), timeOffsetInMinutes(),timeInUtcSeconds());
     }
 }

--- a/src/main/java/com/github/git24j/core/Stash.java
+++ b/src/main/java/com/github/git24j/core/Stash.java
@@ -12,7 +12,7 @@ public final class Stash {
      */
     static native int jniApply(long repoPtr, int index, long options);
 
-    static native int jniApplyOptionsFree(long applyOptionsPtr);
+    static native void jniApplyOptionsFree(long applyOptionsPtr);
 
     /** git_checkout_options checkout_options */
     static native long jniApplyOptionsGetCheckoutOptions(long apply_optionsPtr);

--- a/src/main/java/com/github/git24j/core/Submodule.java
+++ b/src/main/java/com/github/git24j/core/Submodule.java
@@ -143,7 +143,10 @@ public class Submodule extends CAutoReleasable {
     static native void jniUpdateOptionsSetAllowFetch(long update_optionsPtr, int allowFetch);
 
     /** git_checkout_options *checkout_opts */
-    static native void jniUpdateOptionsSetCheckoutOpts(long update_optionsPtr, long checkoutOpts);
+//    static native void jniUpdateOptionsSetCheckoutOpts(long update_optionsPtr, long checkoutOpts);
+
+    /** git_submodule_update_init_options */
+    static native int jniUpdateInitOptions(long updateOptionsPtr, int version);
 
     /** git_submodule_update_t git_submodule_update_strategy(git_submodule *submodule); */
     static native int jniUpdateStrategy(long submodule);

--- a/src/main/java/com/github/git24j/core/Submodule.java
+++ b/src/main/java/com/github/git24j/core/Submodule.java
@@ -2,7 +2,6 @@ package com.github.git24j.core;
 
 import static com.github.git24j.core.GitException.ErrorCode.ENOTFOUND;
 
-import java.net.URI;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -209,13 +208,13 @@ public class Submodule extends CAutoReleasable {
      */
     @Nonnull
     public static Submodule addSetup(
-            @Nonnull Repository repo, @Nonnull URI url, @Nonnull String path, boolean useGitlink) {
+            @Nonnull Repository repo, @Nonnull String url, @Nonnull String path, boolean useGitlink) {
         Submodule out = new Submodule(false, 0);
         Error.throwIfNeeded(
                 jniAddSetup(
                         out._rawPtr,
                         repo.getRawPointer(),
-                        url.toString(),
+                        url,
                         path,
                         useGitlink ? 1 : 0));
         return out;
@@ -267,17 +266,14 @@ public class Submodule extends CAutoReleasable {
      *     resolve string is nto a valid path.
      */
     @Nonnull
-    public static URI resolveUrl(@Nonnull Repository repo, @Nonnull String url) {
+    public static String resolveUrl(@Nonnull Repository repo, @Nonnull String url) {
         Buf out = new Buf();
         Error.throwIfNeeded(jniResolveUrl(out, repo.getRawPointer(), url));
-        return URI.create(
-                out.getString()
-                        .orElseThrow(
-                                () ->
-                                        new IllegalArgumentException(
-                                                String.format(
-                                                        "'%s' cannot be resolved to an absolute URI, check path please",
-                                                        url))));
+        return out.getString().orElseThrow(
+                () -> new IllegalArgumentException(
+                        String.format("'%s' cannot be resolved to an absolute url, check path please", url)
+                )
+        );
     }
 
     /**
@@ -357,8 +353,8 @@ public class Submodule extends CAutoReleasable {
      * @param url URL that should be used for the submodule
      * @throws GitException git errors
      */
-    public static void setUrl(@Nonnull Repository repo, @Nonnull String name, @Nonnull URI url) {
-        Error.throwIfNeeded(jniSetUrl(repo.getRawPointer(), name, url.toString()));
+    public static void setUrl(@Nonnull Repository repo, @Nonnull String name, @Nonnull String url) {
+        Error.throwIfNeeded(jniSetUrl(repo.getRawPointer(), name, url));
     }
 
     /**

--- a/src/main/java/com/github/git24j/core/Submodule.java
+++ b/src/main/java/com/github/git24j/core/Submodule.java
@@ -676,8 +676,14 @@ public class Submodule extends CAutoReleasable {
      *
      * @return the submodule url
      */
+    @Nullable
     public URI url() {
-        return URI.create(jniUrl(getRawPointer()));
+        String urlStr = jniUrl(getRawPointer());
+        if(urlStr == null) {
+            return null;
+        }else {
+            return URI.create(urlStr);
+        }
     }
 
     /**

--- a/src/main/java/com/github/git24j/core/Submodule.java
+++ b/src/main/java/com/github/git24j/core/Submodule.java
@@ -677,13 +677,8 @@ public class Submodule extends CAutoReleasable {
      * @return the submodule url
      */
     @Nullable
-    public URI url() {
-        String urlStr = jniUrl(getRawPointer());
-        if(urlStr == null) {
-            return null;
-        }else {
-            return URI.create(urlStr);
-        }
+    public String url() {
+        return jniUrl(getRawPointer());
     }
 
     /**

--- a/src/main/java/com/github/git24j/core/Tag.java
+++ b/src/main/java/com/github/git24j/core/Tag.java
@@ -328,6 +328,6 @@ public class Tag extends GitObject {
      */
     @FunctionalInterface
     public interface ForeachCb {
-        int accept(String name, String oid);
+        public int accept(String name, String oid);
     }
 }

--- a/src/main/java/com/github/git24j/core/Tag.java
+++ b/src/main/java/com/github/git24j/core/Tag.java
@@ -328,6 +328,6 @@ public class Tag extends GitObject {
      */
     @FunctionalInterface
     public interface ForeachCb {
-        public int accept(String name, String oid);
+        int accept(String name, String oid);
     }
 }

--- a/src/main/java/com/github/git24j/core/Tree.java
+++ b/src/main/java/com/github/git24j/core/Tree.java
@@ -301,7 +301,7 @@ public class Tree extends GitObject {
 
     /** Callback for Tree.walk */
     public interface WalkCb {
-        int accept(String root, Entry entry);
+        public int accept(String root, Entry entry);
     }
 
     /** Representation of each one of the entries in a tree object. */
@@ -544,7 +544,7 @@ public class Tree extends GitObject {
 
         @FunctionalInterface
         public interface FilterCb {
-            int accept(Entry entry);
+            public int accept(Entry entry);
         }
     }
 }

--- a/src/main/java/com/github/git24j/core/Tree.java
+++ b/src/main/java/com/github/git24j/core/Tree.java
@@ -301,7 +301,7 @@ public class Tree extends GitObject {
 
     /** Callback for Tree.walk */
     public interface WalkCb {
-        public int accept(String root, Entry entry);
+        int accept(String root, Entry entry);
     }
 
     /** Representation of each one of the entries in a tree object. */
@@ -544,7 +544,7 @@ public class Tree extends GitObject {
 
         @FunctionalInterface
         public interface FilterCb {
-            public int accept(Entry entry);
+            int accept(Entry entry);
         }
     }
 }

--- a/src/main/java/com/github/git24j/core/WriteStream.java
+++ b/src/main/java/com/github/git24j/core/WriteStream.java
@@ -3,7 +3,7 @@ package com.github.git24j.core;
 public class WriteStream extends CAutoCloseable {
     static native int jniClose(long wsPtr);
 
-    static native int jniFree(long wsPtr);
+    static native void jniFree(long wsPtr);
 
     /** TODO: figure out what's meaning of the return. */
     static native int jniWrite(long wsPtr, byte[] content);

--- a/src/test/java/com/github/git24j/core/CommitTest.java
+++ b/src/test/java/com/github/git24j/core/CommitTest.java
@@ -287,7 +287,7 @@ public class CommitTest extends TestBase {
                             "some commit message",
                             masterTree,
                             Collections.singletonList(master));
-            String bufStr = buf.getPtr();
+            String bufStr = buf.toString();
             /*
             tree 8c5f4d727b339fe7d9ee4d1806aa9ca3a5cc5b3e
             parent 476f0c95825ef4479cab580b71f8b85f9dea4ee4
@@ -319,7 +319,7 @@ public class CommitTest extends TestBase {
                             "some commit message",
                             masterTree,
                             Collections.singletonList(master));
-            Oid oid = Commit.createWithSignature(testRepo, buf.getPtr(), "test signature", null);
+            Oid oid = Commit.createWithSignature(testRepo, buf.toString(), "test signature", null);
             Assert.assertEquals(MASTER_HASH, Commit.lookup(testRepo, oid).parentId(0).toString());
         }
     }

--- a/src/test/java/com/github/git24j/core/RemoteTest.java
+++ b/src/test/java/com/github/git24j/core/RemoteTest.java
@@ -32,7 +32,7 @@ public class RemoteTest extends TestBase {
     @Test
     public void connect() {
         try (Repository testRepo = TestRepo.SIMPLE1.tempRepo(folder)) {
-            Remote r = Remote.create(testRepo, "local", testRepo.workdir().toUri());
+            Remote r = Remote.create(testRepo, "local", testRepo.workdir().toString());
             Remote.Callbacks callbacks = Remote.Callbacks.createDefault();
             r.connect(Remote.Direction.FETCH, callbacks, null, null);
             Assert.assertTrue(r.connected());
@@ -45,11 +45,11 @@ public class RemoteTest extends TestBase {
     @Test
     public void create() {
         try (Repository testRepo = TestRepo.SIMPLE1.tempRepo(folder)) {
-            Remote r = Remote.create(testRepo, "local", testRepo.workdir().toUri());
+            Remote r = Remote.create(testRepo, "local", testRepo.workdir().toString());
             r.fetch(null, null, null);
-            Remote r2 = Remote.createAnonymous(testRepo, testRepo.workdir().toUri());
+            Remote r2 = Remote.createAnonymous(testRepo, testRepo.workdir().toString());
             r2.fetch(null, null, null);
-            Remote r3 = Remote.createDetached(testRepo.workdir().toUri());
+            Remote r3 = Remote.createDetached(testRepo.workdir().toString());
             try {
                 r3.fetch(null, null, null);
                 Assert.fail("should have failed for 'cannot download detached remote'");
@@ -58,11 +58,11 @@ public class RemoteTest extends TestBase {
             }
             Remote r4 =
                     Remote.createWithFetchspec(
-                            testRepo, "local2", testRepo.workdir().toUri(), null);
+                            testRepo, "local2", testRepo.workdir().toString(), null);
             r4.fetch(null, null, null);
 
             Remote.CreateOptions opts = Remote.CreateOptions.createDefault();
-            Remote r5 = Remote.createWithOpts(testRepo.workdir().toUri(), opts);
+            Remote r5 = Remote.createWithOpts(testRepo.workdir().toString(), opts);
             Assert.assertNotNull(r5);
             // r5.fetch(null, null, null);
         }
@@ -83,7 +83,7 @@ public class RemoteTest extends TestBase {
 
     @Test
     public void createWithOpts() {
-        URI url = URI.create("https://github.com/git24j/git24j.git");
+        String url = "https://github.com/git24j/git24j.git";
         Remote r = Remote.createWithOpts(url, null);
         Assert.assertEquals(url, r.url());
         Assert.assertNull(r.defaultBranch());
@@ -107,7 +107,7 @@ public class RemoteTest extends TestBase {
     @Test
     public void fetch() {
         try (Repository remote = creteTestRepo(TestRepo.SIMPLE1_BARE); Repository local = creteTestRepo(TestRepo.SIMPLE1)){
-            Remote upstream = Remote.create(local, "upstream", URI.create(remote.getPath()));
+            Remote upstream = Remote.create(local, "upstream", remote.getPath());
             upstream.fetch(null, null, "reflog");
         }
     }
@@ -154,7 +154,7 @@ public class RemoteTest extends TestBase {
     @Test
     public void setUrl() {
         try (Repository testRepo = TestRepo.SIMPLE1.tempRepo(folder)) {
-            Remote.setUrl(testRepo, "test", URI.create("https://example.com/test.git"));
+            Remote.setUrl(testRepo, "test", "https://example.com/test.git");
             Remote r = Remote.lookup(testRepo, "test");
             Assert.assertEquals(URI.create("https://example.com/test.git"), r.url());
         }


### PR DESCRIPTION
Changes:
1. adapt to libgit2 1.9.0

2. update git24j to 1.9.0(same with libgit2 version)

3. add new method `Repository.isShallow()`, and mark typoed method `Repository.isShadow()` to Deprecated

4. fixed `Diff.getContents()` wrong, it should get content by byte count, not java char count

5. change c pointers check 'pointer<0' to 'pointer==0', because java only signed type, sometimes, even the c pointer < 0 still is a legal pointer

6. improved performance for `Diff.Line.getContent()`

7. `Buf` class changed, for reduce data copy times

8. other bugs fixed
